### PR TITLE
Add publications section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ $ gradle bundledJar
 
 and pick up `build/libs/alpha-bundled.jar`.
 
+## Publications
+
+ * [Antonius Weinzierl: Blending Lazy-Grounding and CDNL Search for Answer-Set Solving](https://doi.org/10.1007/978-3-319-61660-5_17)
+
 ## Suggested Reading
 
  * [Answer Set programming: A Primer](http://www.kr.tuwien.ac.at/staff/tkren/pub/2009/rw2009-asp.pdf)


### PR DESCRIPTION
I think it is fair to refer to publications associated with Alpha.

Still missing:

 * "Introducing Heuristics for Lazy-Grounding ASP Solving"  @ [PAoASP](https://sites.google.com/site/paoasp2017/#accepted)
 * "Techniques for Efficient Lazy-Grounding ASP
Solving" @ [INAP](https://www.uni-wuerzburg.de/fileadmin/10030100/Publications/TR_Declare17.pdf)