### PR TITLE
Moving to sudo-enabled Travis CI (to avoid test failure).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Route our builds to Travis CI's Container Based
 # Infrastructure for shorter queue times.
 # https://docs.travis-ci.com/user/workers/container-based-infrastructure/#Routing-your-build-to-container-based-infrastructure
-sudo: false
+sudo: true
 
 language: java
 


### PR DESCRIPTION
For some unknown reason, Travis CI kills the build while running all tests. Enabling sudo seems to avoid this issue.