### PR TITLE
Restructure AbstractSolverTests

### DIFF
--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/AbstractSolverTests.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/AbstractSolverTests.java
@@ -73,12 +73,26 @@ public abstract class AbstractSolverTests {
 
 	@Parameters(name = "{0}/{1}/{2}/{3}")
 	public static Collection<Object[]> parameters() {
-		String[] solvers = getProperty("solvers", "default");
+		// Check whether we are running in a CI environment.
+		boolean ci = Boolean.valueOf(System.getenv("CI"));
+
+		String[] solvers = getProperty("solvers", ci ? "default" : "default,naive");
 		String[] grounders = getProperty("grounders", "naive");
-		String[] stores = getProperty("stores", "alpharoaming");
-		String[] heuristics = getProperty("heuristics", "NAIVE");
-		String seed = System.getProperty("seed", "");
-		boolean checks = Boolean.valueOf(System.getProperty("test.checks", "false"));
+		String[] stores = getProperty("stores", ci ? "alpharoaming" : "alpharoaming,naive");
+		String[] heuristics = getProperty("heuristics", ci ? "ALL" : "NAIVE");
+
+		// "ALL" is a magic value that will be expanded to contain all heuristics.
+		if ("ALL".equals(heuristics[0])) {
+			BranchingHeuristicFactory.Heuristic[] values = BranchingHeuristicFactory.Heuristic.values();
+			heuristics = new String[values.length];
+			int i = 0;
+			for (BranchingHeuristicFactory.Heuristic heuristic : values) {
+				heuristics[i++] = heuristic.toString();
+			}
+		}
+
+		String seed = System.getProperty("seed", ci ? "0" : "");
+		boolean checks = Boolean.valueOf(System.getProperty("test.checks", String.valueOf(ci)));
 
 		Random random = seed.isEmpty() ? new Random() : new Random(Long.valueOf(seed));
 

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/AbstractSolverTests.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/AbstractSolverTests.java
@@ -27,66 +27,156 @@
  */
 package at.ac.tuwien.kr.alpha.solver;
 
+import at.ac.tuwien.kr.alpha.AnswerSetsParser;
+import at.ac.tuwien.kr.alpha.common.AnswerSet;
+import at.ac.tuwien.kr.alpha.common.Program;
 import at.ac.tuwien.kr.alpha.grounder.Grounder;
-import at.ac.tuwien.kr.alpha.solver.heuristics.BranchingHeuristicFactory.Heuristic;
+import at.ac.tuwien.kr.alpha.grounder.GrounderFactory;
+import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
+import at.ac.tuwien.kr.alpha.solver.heuristics.BranchingHeuristicFactory;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Random;
-import java.util.function.Function;
+import java.io.IOException;
+import java.util.*;
+
+import static java.util.Collections.emptySet;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public abstract class AbstractSolverTests {
-	@Parameters(name = "{0}")
-	public static Collection<Object[]> factories() {
-		boolean enableAdditionalInternalChecks = true;
-		Collection<Object[]> factories = new ArrayList<>();
-		factories.add(new Object[] {"NS", (Function<Grounder, Solver>) NaiveSolver::new});
+	private final ProgramParser parser = new ProgramParser();
 
-		for (Heuristic heuristic : Heuristic.values()) {
-			String name = "DS/R/" + heuristic;
-			Function<Grounder, Solver> instantiator = g -> {
-				ArrayAssignment assignment = new ArrayAssignment(g, enableAdditionalInternalChecks);
-				NoGoodStore store = new NoGoodStoreAlphaRoaming(assignment, enableAdditionalInternalChecks);
-				return new DefaultSolver(g, store, assignment, new Random(), heuristic, enableAdditionalInternalChecks);
-			};
-			factories.add(new Object[] {name, instantiator});
-			name = "DS/R/" + heuristic + "/naive";
-			instantiator = g -> {
-				ArrayAssignment assignment = new ArrayAssignment(g, enableAdditionalInternalChecks);
-				NoGoodStore store = new NaiveNoGoodStore(assignment);
-				return new DefaultSolver(g, store, assignment, new Random(), heuristic, enableAdditionalInternalChecks);
-			};
-			factories.add(new Object[] {name, instantiator});
-			name = "DS/D/" + heuristic;
-			instantiator = g -> {
-				ArrayAssignment assignment = new ArrayAssignment(g, enableAdditionalInternalChecks);
-				NoGoodStore store = new NoGoodStoreAlphaRoaming(assignment, enableAdditionalInternalChecks);
-				return new DefaultSolver(g, store, assignment, new Random(0), heuristic, enableAdditionalInternalChecks);
-			};
-			factories.add(new Object[] {name, instantiator});
-			name = "DS/D/" + heuristic + "/naive";
-			instantiator = g -> {
-				ArrayAssignment assignment = new ArrayAssignment(g, enableAdditionalInternalChecks);
-				NoGoodStore store = new NaiveNoGoodStore(assignment);
-				return new DefaultSolver(g, store, assignment, new Random(0), heuristic, enableAdditionalInternalChecks);
-			};
-			factories.add(new Object[] {name, instantiator});
+	/**
+	 * Sets the logging level to TRACE. Useful for debugging; call at beginning of test case.
+	 */
+	private static void enableTracing() {
+		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+		root.setLevel(ch.qos.logback.classic.Level.TRACE);
+	}
+
+	private static void enableDebugLog() {
+		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+		root.setLevel(Level.DEBUG);
+	}
+
+	private static String[] getProperty(String subKey, String def) {
+		return System.getProperty("test." + subKey, def).split(",");
+	}
+
+	@Parameters(name = "{0}/{1}/{2}/{3}")
+	public static Collection<Object[]> parameters() {
+		String[] solvers = getProperty("solvers", "default");
+		String[] grounders = getProperty("grounders", "naive");
+		String[] stores = getProperty("stores", "alpharoaming");
+		String[] heuristics = getProperty("heuristics", "NAIVE");
+		String seed = System.getProperty("seed", "");
+		boolean checks = Boolean.valueOf(System.getProperty("test.checks", "false"));
+
+		Random random = seed.isEmpty() ? new Random() : new Random(Long.valueOf(seed));
+
+		Collection<Object[]> factories = new ArrayList<>();
+
+		for (String solver : solvers) {
+			for (String grounder : grounders) {
+				for (String store : stores) {
+					for (String heuristic : heuristics) {
+						factories.add(new Object[]{
+							solver, grounder, store, BranchingHeuristicFactory.Heuristic.valueOf(heuristic), random, checks
+						});
+					}
+				}
+			}
 		}
+
 		return factories;
 	}
 
-	@Parameter(value = 0)
+	@Parameter(0)
 	public String solverName;
 
-	@Parameter(value = 1)
-	public Function<Grounder, Solver> factory;
+	@Parameter(1)
+	public String grounderName;
 
-	protected Solver getInstance(Grounder g) {
-		return factory.apply(g);
+	@Parameter(2)
+	public String storeName;
+
+	@Parameter(3)
+	public BranchingHeuristicFactory.Heuristic heuristic;
+
+	@Parameter(4)
+	public Random random;
+
+	@Parameter(5)
+	public boolean checks;
+
+	protected Solver getInstance(Grounder grounder) {
+		return SolverFactory.getInstance(solverName, storeName, grounder, random, heuristic, checks);
+	}
+
+	protected Solver getInstance(Program program) {
+		return getInstance(GrounderFactory.getInstance(grounderName, program));
+	}
+
+	protected Solver getInstance(String program) {
+		return getInstance(CharStreams.fromString(program));
+	}
+
+	protected Solver getInstance(CharStream program) {
+		try {
+			return getInstance(parser.parse(program));
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Set<AnswerSet> collectSet(String program) {
+		return getInstance(program).collectSet();
+	}
+
+	protected Set<AnswerSet> collectSet(Program program) {
+		return getInstance(program).collectSet();
+	}
+
+	protected Set<AnswerSet> collectSet(CharStream program) {
+		return getInstance(program).collectSet();
+	}
+
+	protected void assertAnswerSets(String program, String... answerSets) throws IOException {
+		if (answerSets.length == 0) {
+			assertAnswerSets(program, emptySet());
+			return;
+		}
+
+		StringJoiner joiner = new StringJoiner("} {", "{", "}");
+		Arrays.stream(answerSets).forEach(joiner::add);
+		assertAnswerSets(program, AnswerSetsParser.parse(joiner.toString()));
+	}
+
+	protected void assertAnswerSet(String program, String answerSet) throws IOException {
+		assertAnswerSets(program, AnswerSetsParser.parse("{ " + answerSet + " }"));
+	}
+
+	protected void assertAnswerSetsWithBase(String program, String base, String... answerSets) throws IOException {
+		if (!base.endsWith(",")) {
+			base += ", ";
+		}
+
+		for (int i = 0; i < answerSets.length; i++) {
+			answerSets[i] = base + answerSets[i];
+		}
+
+		assertAnswerSets(program, answerSets);
+	}
+
+	protected void assertAnswerSets(String program, Set<AnswerSet> answerSets) throws IOException {
+		assertEquals(answerSets, collectSet(program));
 	}
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/ChoiceManagerTests.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/ChoiceManagerTests.java
@@ -31,11 +31,8 @@ import at.ac.tuwien.kr.alpha.grounder.Grounder;
 import at.ac.tuwien.kr.alpha.grounder.NaiveGrounder;
 import at.ac.tuwien.kr.alpha.grounder.atoms.RuleAtom;
 import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -44,19 +41,6 @@ import static at.ac.tuwien.kr.alpha.common.Literals.atomOf;
 import static org.junit.Assert.assertTrue;
 
 public class ChoiceManagerTests extends AbstractSolverTests {
-	/**
-	 * Sets the logging level to TRACE. Useful for debugging; call at beginning of test case.
-	 */
-	private static void enableTracing() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(ch.qos.logback.classic.Level.TRACE);
-	}
-
-	private static void enableDebugLog() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(Level.DEBUG);
-	}
-
 	private Grounder grounder;
 	private ChoiceManager choiceManager;
 

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/HanoiTowerTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/HanoiTowerTest.java
@@ -32,15 +32,11 @@ import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
 import at.ac.tuwien.kr.alpha.common.predicates.Predicate;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;
-import at.ac.tuwien.kr.alpha.grounder.NaiveGrounder;
 import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import org.antlr.v4.runtime.CharStreams;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -56,19 +52,6 @@ import static org.junit.Assert.assertTrue;
 @Ignore("disabled to save resources during CI")
 public class HanoiTowerTest extends AbstractSolverTests {
 	private final ProgramParser parser = new ProgramParser();
-
-	/**
-	 * Sets the logging level to TRACE. Useful for debugging; call at beginning of test case.
-	 */
-	private static void enableTracing() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(ch.qos.logback.classic.Level.TRACE);
-	}
-
-	private static void enableDebugLog() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(Level.DEBUG);
-	}
 
 	@Before
 	public void printSolverName() {
@@ -107,8 +90,7 @@ public class HanoiTowerTest extends AbstractSolverTests {
 	private void testHanoiTower(String instance) throws IOException {
 		Program parsedProgram = parser.parse(CharStreams.fromPath(Paths.get("src", "test", "resources", "HanoiTower_Alpha.asp")));
 		parsedProgram.accumulate(parser.parse(CharStreams.fromPath(Paths.get("src", "test", "resources", "HanoiTower_instances", instance + ".asp"))));
-		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
-		Solver solver = getInstance(grounder);
+		Solver solver = getInstance(parsedProgram);
 		Optional<AnswerSet> answerSet = solver.stream().findFirst();
 		assertTrue(answerSet.isPresent());
 		System.out.println(answerSet.get());

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/OmigaBenchmarksTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/OmigaBenchmarksTest.java
@@ -26,17 +26,11 @@
 package at.ac.tuwien.kr.alpha.solver;
 
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
-import at.ac.tuwien.kr.alpha.common.Program;
-import at.ac.tuwien.kr.alpha.grounder.NaiveGrounder;
-import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -47,19 +41,6 @@ import java.util.Optional;
  *
  */
 public class OmigaBenchmarksTest extends AbstractSolverTests {
-	/**
-	 * Sets the logging level to TRACE. Useful for debugging; call at beginning of test case.
-	 */
-	private static void enableTracing() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(ch.qos.logback.classic.Level.TRACE);
-	}
-
-	private static void enableDebugLog() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(Level.DEBUG);
-	}
-
 	@Before
 	public void printSolverName() {
 		System.out.println(solverName);
@@ -115,9 +96,7 @@ public class OmigaBenchmarksTest extends AbstractSolverTests {
 		CharStream programInputStream = CharStreams.fromPath(
 			Paths.get("benchmarks", "omiga", "omiga-testcases", folder, aspFileName)
 		);
-		Program parsedProgram = new ProgramParser().parse(programInputStream);
-		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
-		Solver solver = getInstance(grounder);
+		Solver solver = getInstance(programInputStream);
 		Optional<AnswerSet> answerSet = solver.stream().findFirst();
 		System.out.println(answerSet);
 		// TODO: check correctness of answer set

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/PartSubpartConfigurationTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/PartSubpartConfigurationTest.java
@@ -25,46 +25,22 @@
  */
 package at.ac.tuwien.kr.alpha.solver;
 
-import at.ac.tuwien.kr.alpha.common.AnswerSet;
-import at.ac.tuwien.kr.alpha.common.Program;
-import at.ac.tuwien.kr.alpha.grounder.NaiveGrounder;
-import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertFalse;
 
 /**
  * Tests {@link AbstractSolver} using some configuration test cases in which subparts are assigned to parts.
  *
  */
 public class PartSubpartConfigurationTest extends AbstractSolverTests {
-	/**
-	 * Sets the logging level to TRACE. Useful for debugging; call at beginning of test case.
-	 */
-	private static void enableTracing() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(ch.qos.logback.classic.Level.TRACE);
-	}
-
-	private static void enableDebugLog() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(Level.DEBUG);
-	}
-
-	@Before
-	public void printSolverName() {
-		System.out.print(solverName);
-	}
-
 	@Test(timeout = 1000)
 	public void testN2() throws IOException {
 		testPartSubpart(2);
@@ -117,22 +93,19 @@ public class PartSubpartConfigurationTest extends AbstractSolverTests {
 		for (int i = 1; i <= n; i++) {
 			rules.add(String.format("n(%d).", i));
 		}
-		rules.add("part(N) :- n(N), not no_part(N).");
-		rules.add("no_part(N) :- n(N), not part(N).");
-		rules.add("subpartid(SP,ID) :- subpart(SP,P), n(ID), not no_subpartid(SP,ID).");
-		rules.add("no_subpartid(SP,ID) :- subpart(SP,P), n(ID), not subpartid(SP,ID).");
-		rules.add("subpart(SP,P) :- part(P), part(SP), P != SP, not no_subpart(SP,P).");
-		rules.add("no_subpart(SP,P) :- part(P), part(SP), P != SP, not subpart(SP,P).");
-		rules.add(":- subpart(SP,P1), subpart(SP,P2), P1 != P2.");
-		rules.add(":- subpart(SP1,P), subpart(SP2, P), SP1!=SP2, subpartid(SP1,ID), subpartid(SP2,ID).");
 
-		String testProgram = concat(rules);
-		Program parsedProgram = new ProgramParser().parse(testProgram);
-		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
-		Solver solver = getInstance(grounder);
+		rules.addAll(Arrays.asList(
+			"part(N) :- n(N), not no_part(N).",
+			"no_part(N) :- n(N), not part(N).",
+			"subpartid(SP,ID) :- subpart(SP,P), n(ID), not no_subpartid(SP,ID).",
+			"no_subpartid(SP,ID) :- subpart(SP,P), n(ID), not subpartid(SP,ID).",
+			"subpart(SP,P) :- part(P), part(SP), P != SP, not no_subpart(SP,P).",
+			"no_subpart(SP,P) :- part(P), part(SP), P != SP, not subpart(SP,P).",
+			":- subpart(SP,P1), subpart(SP,P2), P1 != P2.",
+			":- subpart(SP1,P), subpart(SP2, P), SP1!=SP2, subpartid(SP1,ID), subpartid(SP2,ID)."
+		));
 
-		Optional<AnswerSet> answerSet = solver.stream().findAny();
-		System.out.println(answerSet);
+		assertFalse(collectSet(concat(rules)).isEmpty());
 		// TODO: check correctness of answer set
 	}
 
@@ -140,5 +113,4 @@ public class PartSubpartConfigurationTest extends AbstractSolverTests {
 		String ls = System.lineSeparator();
 		return rules.stream().collect(Collectors.joining(ls));
 	}
-
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/PigeonHoleTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/PigeonHoleTest.java
@@ -118,7 +118,7 @@ public class PigeonHoleTest extends AbstractSolverTests {
 	}
 
 	/**
-	 * Tries to collectSet the problem of assigning P pigeons to H holes.
+	 * Tries to solve the problem of assigning P pigeons to H holes.
 	 */
 	private void testPigeonsHoles(int pigeons, int holes) throws IOException {
 		List<String> rules = new ArrayList<>();

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/PigeonHoleTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/PigeonHoleTest.java
@@ -26,16 +26,8 @@
 package at.ac.tuwien.kr.alpha.solver;
 
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
-import at.ac.tuwien.kr.alpha.common.Program;
-import at.ac.tuwien.kr.alpha.grounder.NaiveGrounder;
-import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -43,29 +35,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * Tests {@link AbstractSolver} using some pigeon-hole test cases (see https://en.wikipedia.org/wiki/Pigeonhole_principle).
  *
  */
 public class PigeonHoleTest extends AbstractSolverTests {
-	/**
-	 * Sets the logging level to TRACE. Useful for debugging; call at beginning of test case.
-	 */
-	private static void enableTracing() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(ch.qos.logback.classic.Level.TRACE);
-	}
-
-	private static void enableDebugLog() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(Level.DEBUG);
-	}
-
-	@Before
-	public void printSolverName() {
-		System.out.println(solverName);
-	}
-
 	@Test(timeout = 1000)
 	public void test2Pigeons2Holes() throws IOException {
 		testPigeonsHoles(2, 2);
@@ -142,7 +118,7 @@ public class PigeonHoleTest extends AbstractSolverTests {
 	}
 
 	/**
-	 * Tries to solve the problem of assigning P pigeons to H holes.
+	 * Tries to collectSet the problem of assigning P pigeons to H holes.
 	 */
 	private void testPigeonsHoles(int pigeons, int holes) throws IOException {
 		List<String> rules = new ArrayList<>();
@@ -156,15 +132,8 @@ public class PigeonHoleTest extends AbstractSolverTests {
 		addPigeons(rules, pigeons);
 		addHoles(rules, holes);
 
-		String testProgram = concat(rules);
-		Program parsedProgram = new ProgramParser().parse(testProgram);
-		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
-
-		Solver solver = getInstance(grounder);
-
-		Set<AnswerSet> answerSets = solver.collectSet();
-		Assert.assertEquals(numberOfSolutions(pigeons, holes), answerSets.size());
-		solver.stream().findAny();
+		Set<AnswerSet> answerSets = collectSet(concat(rules));
+		assertEquals(numberOfSolutions(pigeons, holes), answerSets.size());
 	}
 
 	private void addPigeons(List<String> rules, int pigeons) {

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/RacksTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/RacksTest.java
@@ -26,17 +26,11 @@
 package at.ac.tuwien.kr.alpha.solver;
 
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
-import at.ac.tuwien.kr.alpha.common.Program;
-import at.ac.tuwien.kr.alpha.grounder.NaiveGrounder;
-import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -48,21 +42,6 @@ import java.util.Optional;
  */
 @Ignore("disabled to save resources during CI")
 public class RacksTest extends AbstractSolverTests {
-	private final ProgramParser parser = new ProgramParser();
-
-	/**
-	 * Sets the logging level to TRACE. Useful for debugging; call at beginning of test case.
-	 */
-	private static void enableTracing() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(ch.qos.logback.classic.Level.TRACE);
-	}
-
-	private static void enableDebugLog() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(Level.DEBUG);
-	}
-
 	@Before
 	public void printSolverName() {
 		System.out.println(solverName);
@@ -77,9 +56,7 @@ public class RacksTest extends AbstractSolverTests {
 		CharStream programInputStream = CharStreams.fromPath(
 			Paths.get("benchmarks", "siemens", "racks", "racks.lp")
 		);
-		Program parsedProgram = parser.parse(programInputStream);
-		NaiveGrounder grounder = new NaiveGrounder(parsedProgram);
-		Solver solver = getInstance(grounder);
+		Solver solver = getInstance(programInputStream);
 		Optional<AnswerSet> answerSet = solver.stream().findFirst();
 		System.out.println(answerSet);
 		// TODO: check correctness of answer set

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/SolverTests.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/SolverTests.java
@@ -27,44 +27,24 @@
  */
 package at.ac.tuwien.kr.alpha.solver;
 
-import at.ac.tuwien.kr.alpha.AnswerSetsParser;
-import at.ac.tuwien.kr.alpha.common.*;
+import at.ac.tuwien.kr.alpha.common.AnswerSetBuilder;
+import at.ac.tuwien.kr.alpha.common.Program;
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
 import at.ac.tuwien.kr.alpha.common.predicates.Predicate;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.grounder.ChoiceGrounder;
 import at.ac.tuwien.kr.alpha.grounder.DummyGrounder;
-import at.ac.tuwien.kr.alpha.grounder.NaiveGrounder;
-import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
+import junit.framework.TestCase;
 import org.junit.Test;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
 
-import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 
 public class SolverTests extends AbstractSolverTests {
-	private final ProgramParser parser = new ProgramParser();
-
-	/**
-	 * Sets the logging level to TRACE. Useful for debugging; call at beginning of test case.
-	 */
-	private static void enableTracing() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(ch.qos.logback.classic.Level.TRACE);
-	}
-
-	private static void enableDebugLog() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(Level.DEBUG);
-	}
-
 	private static class Thingy implements Comparable<Thingy> {
 		@Override
 		public String toString() {
@@ -90,7 +70,7 @@ public class SolverTests extends AbstractSolverTests {
 
 		assertEquals(singleton(new AnswerSetBuilder()
 			.predicate("foo").instance(thingy)
-			.build()), solve(program));
+			.build()), collectSet(program));
 	}
 
 	@Test
@@ -159,16 +139,6 @@ public class SolverTests extends AbstractSolverTests {
 			"p(1), q(2), q(3)",
 			"p(1), p(2), q(3)"
 		);
-	}
-
-	@Test
-	public void dummyGrounder() {
-		assertEquals(DummyGrounder.EXPECTED, getInstance(new DummyGrounder()).collectSet());
-	}
-
-	@Test
-	public void choiceGrounder() {
-		assertEquals(ChoiceGrounder.EXPECTED, getInstance(new ChoiceGrounder()).collectSet());
 	}
 
 	@Test
@@ -558,42 +528,13 @@ public class SolverTests extends AbstractSolverTests {
 		);
 	}
 
-	private Set<AnswerSet> solve(String program) throws IOException {
-		return solve(parser.parse(program));
+	@Test
+	public void dummyGrounder() {
+		TestCase.assertEquals(DummyGrounder.EXPECTED, getInstance(new DummyGrounder()).collectSet());
 	}
 
-	private Set<AnswerSet> solve(Program program) throws IOException {
-		return getInstance(new NaiveGrounder(program)).collectSet();
-	}
-
-	private void assertAnswerSets(String program, String... answerSets) throws IOException {
-		if (answerSets.length == 0) {
-			assertAnswerSets(program, emptySet());
-			return;
-		}
-
-		StringJoiner joiner = new StringJoiner("} {", "{", "}");
-		Arrays.stream(answerSets).forEach(joiner::add);
-		assertAnswerSets(program, AnswerSetsParser.parse(joiner.toString()));
-	}
-
-	private void assertAnswerSet(String program, String answerSet) throws IOException {
-		assertAnswerSets(program, AnswerSetsParser.parse("{ " + answerSet + " }"));
-	}
-
-	private void assertAnswerSetsWithBase(String program, String base, String... answerSets) throws IOException {
-		if (!base.endsWith(",")) {
-			base += ", ";
-		}
-
-		for (int i = 0; i < answerSets.length; i++) {
-			answerSets[i] = base + answerSets[i];
-		}
-
-		assertAnswerSets(program, answerSets);
-	}
-
-	private void assertAnswerSets(String program, Set<AnswerSet> answerSets) throws IOException {
-		assertEquals(answerSets, solve(program));
+	@Test
+	public void choiceGrounder() {
+		TestCase.assertEquals(ChoiceGrounder.EXPECTED, getInstance(new ChoiceGrounder()).collectSet());
 	}
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/ThreeColouringRandomGraphTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/ThreeColouringRandomGraphTest.java
@@ -32,37 +32,14 @@ import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
 import at.ac.tuwien.kr.alpha.common.predicates.Predicate;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;
-import at.ac.tuwien.kr.alpha.grounder.NaiveGrounder;
 import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
 
 public class ThreeColouringRandomGraphTest extends AbstractSolverTests {
-	/**
-	 * Sets the logging level to TRACE. Useful for debugging; call at beginning of test case.
-	 */
-	private static void enableTracing() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(ch.qos.logback.classic.Level.TRACE);
-	}
-
-	private static void enableDebugLog() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(Level.DEBUG);
-	}
-
-	@Before
-	public void printSolverName() {
-		System.out.println(solverName);
-	}
-
 	@Test(timeout = 1000)
 	public void testV3E3() throws IOException {
 		testThreeColouring(3, 3);
@@ -118,10 +95,7 @@ public class ThreeColouringRandomGraphTest extends AbstractSolverTests {
 
 		maybeShuffle(program);
 
-		NaiveGrounder grounder = new NaiveGrounder(program);
-		Solver solver = getInstance(grounder);
-
-		Optional<AnswerSet> answerSet = solver.stream().findAny();
+		Optional<AnswerSet> answerSet = getInstance(program).stream().findAny();
 		System.out.println(answerSet);
 
 		// TODO: check correctness of answer set

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/ThreeColouringTestWithRandom.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/ThreeColouringTestWithRandom.java
@@ -34,14 +34,9 @@ import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
 import at.ac.tuwien.kr.alpha.common.predicates.Predicate;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;
-import at.ac.tuwien.kr.alpha.grounder.NaiveGrounder;
 import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
@@ -54,24 +49,6 @@ import java.util.*;
  * DOI: 10.1017/S1471068416000569
  */
 public class ThreeColouringTestWithRandom extends AbstractSolverTests {
-	/**
-	 * Sets the logging level to TRACE. Useful for debugging; call at beginning of test case.
-	 */
-	private static void enableTracing() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(ch.qos.logback.classic.Level.TRACE);
-	}
-
-	private static void enableDebugLog() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(Level.DEBUG);
-	}
-
-	@Before
-	public void printSolverName() {
-		System.out.println(solverName);
-	}
-
 	@Test(timeout = 3000)
 	public void testN3() throws IOException {
 		testThreeColouring(3, false, 0);
@@ -184,8 +161,7 @@ public class ThreeColouringTestWithRandom extends AbstractSolverTests {
 		program.getFacts().addAll(createVertices(n));
 		program.getFacts().addAll(createEdges(n, shuffle, seed));
 
-		NaiveGrounder grounder = new NaiveGrounder(program);
-		Solver solver = getInstance(grounder);
+		Solver solver = getInstance(program);
 
 		StringBuilder sb = new StringBuilder();
 

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/ThreeColouringWheelTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/ThreeColouringWheelTest.java
@@ -32,14 +32,9 @@ import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
 import at.ac.tuwien.kr.alpha.common.predicates.Predicate;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;
-import at.ac.tuwien.kr.alpha.grounder.NaiveGrounder;
 import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -55,24 +50,6 @@ import java.util.Optional;
  * DOI: 10.1017/S1471068416000569
  */
 public class ThreeColouringWheelTest extends AbstractSolverTests {
-	/**
-	 * Sets the logging level to TRACE. Useful for debugging; call at beginning of test case.
-	 */
-	private static void enableTracing() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(ch.qos.logback.classic.Level.TRACE);
-	}
-
-	private static void enableDebugLog() {
-		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-		root.setLevel(Level.DEBUG);
-	}
-
-	@Before
-	public void printSolverName() {
-		System.out.println(solverName);
-	}
-
 	@Test(timeout = 1000)
 	public void testN4() throws IOException {
 		testThreeColouring(4);
@@ -118,8 +95,7 @@ public class ThreeColouringWheelTest extends AbstractSolverTests {
 
 		maybeShuffle(program);
 
-		NaiveGrounder grounder = new NaiveGrounder(program);
-		Solver solver = getInstance(grounder);
+		Solver solver = getInstance(program);
 
 		Optional<AnswerSet> answerSet = solver.stream().findAny();
 		System.out.println(answerSet);


### PR DESCRIPTION
Do not test so many configurations by default, just one. Allow setting configurations to be tested via properties.

This also allows for testing multiple grounder implementations.