### PR TITLE
Showing coverage badge for master branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Travis-CI Build Status](https://travis-ci.org/alpha-asp/Alpha.svg?branch=master)](https://travis-ci.org/alpha-asp/Alpha)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/3wrwa7on0en01y7u?svg=true)](https://ci.appveyor.com/project/lorenzleutgeb/alpha)
-[![Coverage Status](https://coveralls.io/repos/github/alpha-asp/Alpha/badge.svg?branch=ci)](https://coveralls.io/github/alpha-asp/Alpha?branch=ci)
+[![Coverage Status](https://coveralls.io/repos/github/alpha-asp/Alpha/badge.svg?branch=master)](https://coveralls.io/github/alpha-asp/Alpha?branch=master)
 [![Code Quality Status](https://codebeat.co/badges/10b609be-9774-42a1-b7fe-2bb64382744d)](https://codebeat.co/projects/github-com-alpha-asp-alpha-master)
 
 Alpha is the successor of [OMiGA](http://www.kr.tuwien.ac.at/research/systems/omiga/) and currently in development.


### PR DESCRIPTION
Current Coveralls badge is taken from old `ci` branch, not `master`.