### PR TITLE
Renaming interpretations to fixed interpretations.

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/Alpha.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/Alpha.java
@@ -4,7 +4,7 @@ import at.ac.tuwien.kr.alpha.common.AnswerSet;
 import at.ac.tuwien.kr.alpha.common.Program;
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
-import at.ac.tuwien.kr.alpha.common.interpretations.*;
+import at.ac.tuwien.kr.alpha.common.fixedinterpretations.*;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.grounder.Grounder;
 import at.ac.tuwien.kr.alpha.grounder.GrounderFactory;

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/Predicate.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/Predicate.java
@@ -7,12 +7,12 @@ public class Predicate implements Comparable<Predicate> {
 	private static final Interner<Predicate> INTERNER = new Interner<>();
 
 	private final String name;
-	private final int rank;
+	private final int arity;
 	private final boolean internal;
 
-	protected Predicate(String name, int rank, boolean internal) {
+	protected Predicate(String name, int arity, boolean internal) {
 		this.name = name;
-		this.rank = rank;
+		this.arity = arity;
 		this.internal = internal;
 	}
 
@@ -27,7 +27,7 @@ public class Predicate implements Comparable<Predicate> {
 	@Override
 	public int hashCode() {
 		int result = name != null ? name.hashCode() : 0;
-		result = 31 * result + rank;
+		result = 31 * result + arity;
 		result = 31 * result + (internal ? 1 : 0);
 		return result;
 	}
@@ -44,7 +44,7 @@ public class Predicate implements Comparable<Predicate> {
 
 		Predicate predicate = (Predicate) o;
 
-		if (rank != predicate.rank) {
+		if (arity != predicate.arity) {
 			return false;
 		}
 
@@ -75,6 +75,6 @@ public class Predicate implements Comparable<Predicate> {
 	}
 
 	public int getArity() {
-		return rank;
+		return arity;
 	}
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ComparisonAtom.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ComparisonAtom.java
@@ -14,7 +14,7 @@ import java.util.*;
  * Represents a builtin atom according to the standard.
  * Copyright (c) 2017, the Alpha Team.
  */
-public class ComparisonAtom implements InterpretableLiteral {
+public class ComparisonAtom implements FixedInterpretationLiteral {
 	private final Predicate predicate;
 	private final ComparisonOperator operator;
 	private final List<Term> terms;

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalAtom.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalAtom.java
@@ -1,7 +1,7 @@
 package at.ac.tuwien.kr.alpha.common.atoms;
 
 import at.ac.tuwien.kr.alpha.common.Predicate;
-import at.ac.tuwien.kr.alpha.common.interpretations.PredicateInterpretation;
+import at.ac.tuwien.kr.alpha.common.fixedinterpretations.PredicateInterpretation;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;
 import at.ac.tuwien.kr.alpha.common.terms.VariableTerm;
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 import static at.ac.tuwien.kr.alpha.Util.join;
 import static java.util.Collections.emptyList;
 
-public class ExternalAtom implements InterpretableLiteral {
+public class ExternalAtom implements FixedInterpretationLiteral {
 	private final List<Term> input;
 	private final List<Term> output;
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/FixedInterpretationLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/FixedInterpretationLiteral.java
@@ -9,6 +9,6 @@ import java.util.List;
  * Examples of such atoms are builtin atoms and external atoms.
  * Copyright (c) 2017, the Alpha Team.
  */
-public interface InterpretableLiteral extends Literal {
+public interface FixedInterpretationLiteral extends Literal {
 	List<Substitution> getSubstitutions(Substitution partialSubstitution);
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/BinaryPredicateInterpretation.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/BinaryPredicateInterpretation.java
@@ -1,4 +1,4 @@
-package at.ac.tuwien.kr.alpha.common.interpretations;
+package at.ac.tuwien.kr.alpha.common.fixedinterpretations;
 
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/BindingMethodPredicateInterpretation.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/BindingMethodPredicateInterpretation.java
@@ -1,4 +1,4 @@
-package at.ac.tuwien.kr.alpha.common.interpretations;
+package at.ac.tuwien.kr.alpha.common.fixedinterpretations;
 
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/BindingPredicateInterpretation.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/BindingPredicateInterpretation.java
@@ -1,4 +1,4 @@
-package at.ac.tuwien.kr.alpha.common.interpretations;
+package at.ac.tuwien.kr.alpha.common.fixedinterpretations;
 
 /**
  * This interface is used to mark predicate interpretations that might generate

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/IntPredicateInterpretation.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/IntPredicateInterpretation.java
@@ -1,4 +1,4 @@
-package at.ac.tuwien.kr.alpha.common.interpretations;
+package at.ac.tuwien.kr.alpha.common.fixedinterpretations;
 
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/LongPredicateInterpretation.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/LongPredicateInterpretation.java
@@ -1,4 +1,4 @@
-package at.ac.tuwien.kr.alpha.common.interpretations;
+package at.ac.tuwien.kr.alpha.common.fixedinterpretations;
 
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/MethodPredicateInterpretation.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/MethodPredicateInterpretation.java
@@ -1,4 +1,4 @@
-package at.ac.tuwien.kr.alpha.common.interpretations;
+package at.ac.tuwien.kr.alpha.common.fixedinterpretations;
 
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import org.apache.commons.lang3.ClassUtils;

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/NonBindingPredicateInterpretation.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/NonBindingPredicateInterpretation.java
@@ -1,4 +1,4 @@
-package at.ac.tuwien.kr.alpha.common.interpretations;
+package at.ac.tuwien.kr.alpha.common.fixedinterpretations;
 
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/PredicateInterpretation.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/PredicateInterpretation.java
@@ -1,4 +1,4 @@
-package at.ac.tuwien.kr.alpha.common.interpretations;
+package at.ac.tuwien.kr.alpha.common.fixedinterpretations;
 
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/SuppliedPredicateInterpretation.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/SuppliedPredicateInterpretation.java
@@ -1,4 +1,4 @@
-package at.ac.tuwien.kr.alpha.common.interpretations;
+package at.ac.tuwien.kr.alpha.common.fixedinterpretations;
 
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/UnaryPredicateInterpretation.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/UnaryPredicateInterpretation.java
@@ -1,4 +1,4 @@
-package at.ac.tuwien.kr.alpha.common.interpretations;
+package at.ac.tuwien.kr.alpha.common.fixedinterpretations;
 
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/terms/ConstantTerm.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/terms/ConstantTerm.java
@@ -55,8 +55,6 @@ public class ConstantTerm<T extends Comparable<T>> extends Term {
 			}
 		}
 		return object.toString();
-
-		// return object + "/" + rank;
 	}
 
 	@Override

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
@@ -30,7 +30,7 @@ package at.ac.tuwien.kr.alpha.grounder;
 import at.ac.tuwien.kr.alpha.common.*;
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
-import at.ac.tuwien.kr.alpha.common.atoms.InterpretableLiteral;
+import at.ac.tuwien.kr.alpha.common.atoms.FixedInterpretationLiteral;
 import at.ac.tuwien.kr.alpha.common.atoms.Literal;
 import at.ac.tuwien.kr.alpha.common.Predicate;
 import at.ac.tuwien.kr.alpha.common.terms.Term;
@@ -391,9 +391,9 @@ public class NaiveGrounder extends BridgedGrounder {
 		}
 
 		Literal currentAtom = groundingOrder[orderPosition];
-		if (currentAtom instanceof InterpretableLiteral) {
+		if (currentAtom instanceof FixedInterpretationLiteral) {
 			// Generate all substitutions for the builtin/external/interval atom.
-			List<Substitution> substitutions = ((InterpretableLiteral)currentAtom).getSubstitutions(partialSubstitution);
+			List<Substitution> substitutions = ((FixedInterpretationLiteral)currentAtom).getSubstitutions(partialSubstitution);
 
 			if (substitutions.isEmpty()) {
 				return emptyList();

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/NoGoodGenerator.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/NoGoodGenerator.java
@@ -2,7 +2,7 @@ package at.ac.tuwien.kr.alpha.grounder;
 
 import at.ac.tuwien.kr.alpha.common.NoGood;
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
-import at.ac.tuwien.kr.alpha.common.atoms.InterpretableLiteral;
+import at.ac.tuwien.kr.alpha.common.atoms.FixedInterpretationLiteral;
 import at.ac.tuwien.kr.alpha.grounder.atoms.ChoiceAtom;
 import at.ac.tuwien.kr.alpha.grounder.atoms.RuleAtom;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -48,7 +48,7 @@ public class NoGoodGenerator {
 		ArrayList<Integer> bodyAtomsNegative = new ArrayList<>();
 		// FIXME: iterate on literals of the rule instead of NonGroundRule.
 		for (Atom atom : nonGroundRule.getBodyAtomsPositive()) {
-			if (atom instanceof InterpretableLiteral) {
+			if (atom instanceof FixedInterpretationLiteral) {
 				// Atom has fixed interpretation, hence was checked earlier that it evaluates to true under the given substitution.
 				// FixedInterpretationAtoms need not be shown to the solver, skip it.
 				continue;

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/atoms/IntervalAtom.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/atoms/IntervalAtom.java
@@ -1,7 +1,7 @@
 package at.ac.tuwien.kr.alpha.grounder.atoms;
 
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
-import at.ac.tuwien.kr.alpha.common.atoms.InterpretableLiteral;
+import at.ac.tuwien.kr.alpha.common.atoms.FixedInterpretationLiteral;
 import at.ac.tuwien.kr.alpha.common.Predicate;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.IntervalTerm;
@@ -27,7 +27,7 @@ import static at.ac.tuwien.kr.alpha.Util.join;
  * with the Integer being inside the interval.
  * Copyright (c) 2017, the Alpha Team.
  */
-public class IntervalAtom implements InterpretableLiteral {
+public class IntervalAtom implements FixedInterpretationLiteral {
 	private static final Predicate INTERVAL_PREDICATE = Predicate.getInstance("_interval", 2, true);
 
 	private final List<Term> terms;

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ParseTreeVisitor.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ParseTreeVisitor.java
@@ -5,7 +5,7 @@ import at.ac.tuwien.kr.alpha.antlr.ASPCore2Lexer;
 import at.ac.tuwien.kr.alpha.antlr.ASPCore2Parser;
 import at.ac.tuwien.kr.alpha.common.*;
 import at.ac.tuwien.kr.alpha.common.atoms.*;
-import at.ac.tuwien.kr.alpha.common.interpretations.PredicateInterpretation;
+import at.ac.tuwien.kr.alpha.common.fixedinterpretations.PredicateInterpretation;
 import at.ac.tuwien.kr.alpha.common.Predicate;
 import at.ac.tuwien.kr.alpha.common.terms.*;
 import org.antlr.v4.runtime.RuleContext;

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ProgramParser.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ProgramParser.java
@@ -4,7 +4,7 @@ import at.ac.tuwien.kr.alpha.CustomErrorListener;
 import at.ac.tuwien.kr.alpha.antlr.ASPCore2Lexer;
 import at.ac.tuwien.kr.alpha.antlr.ASPCore2Parser;
 import at.ac.tuwien.kr.alpha.common.Program;
-import at.ac.tuwien.kr.alpha.common.interpretations.PredicateInterpretation;
+import at.ac.tuwien.kr.alpha.common.fixedinterpretations.PredicateInterpretation;
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.misc.ParseCancellationException;

--- a/src/test/java/at/ac/tuwien/kr/alpha/AlphaTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/AlphaTest.java
@@ -3,7 +3,7 @@ package at.ac.tuwien.kr.alpha;
 import at.ac.tuwien.kr.alpha.common.*;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
 import at.ac.tuwien.kr.alpha.common.atoms.ExternalAtom;
-import at.ac.tuwien.kr.alpha.common.interpretations.MethodPredicateInterpretation;
+import at.ac.tuwien.kr.alpha.common.fixedinterpretations.MethodPredicateInterpretation;
 import at.ac.tuwien.kr.alpha.common.Predicate;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import org.junit.Ignore;


### PR DESCRIPTION
Renaming package `common.interpretations` to `common.fixedinterpretations` and the interface `InterpretableLiteral` to `FixedInterpretationLiteral`.