### PR TITLE
Statistics: Print number of conflicts after closing

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017, the Alpha Team.
+ * Copyright (c) 2016-2018, the Alpha Team.
  * All rights reserved.
  *
  * Additional changes made by Siemens.
@@ -65,6 +65,7 @@ public class DefaultSolver extends AbstractSolver implements SolverMaintainingSt
 
 	private boolean initialize = true;
 	private int mbtAtFixpoint;
+	private int conflictsAfterClosing;
 
 	public DefaultSolver(Grounder grounder, NoGoodStore store, WritableAssignment assignment, Random random, Heuristic branchingHeuristic, boolean debugInternalChecks) {
 		super(grounder);
@@ -134,6 +135,7 @@ public class DefaultSolver extends AbstractSolver implements SolverMaintainingSt
 				} else {
 					// Will not learn from violated NoGood, do simple backtrackSlow.
 					LOGGER.debug("NoGood was violated after all unassigned atoms were assigned to false; will not learn from it; skipping.");
+					conflictsAfterClosing++;
 					if (!backtrack()) {
 						logStats();
 						return false;
@@ -378,6 +380,11 @@ public class DefaultSolver extends AbstractSolver implements SolverMaintainingSt
 	@Override
 	public int getNumberOfBacktracksDueToRemnantMBTs() {
 		return mbtAtFixpoint;
+	}
+	
+	@Override
+	public int getNumberOfConflictsAfterClosing() {
+		return conflictsAfterClosing;
 	}
 
 	private void logStats() {

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/SolverMaintainingStatistics.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/SolverMaintainingStatistics.java
@@ -48,6 +48,10 @@ public interface SolverMaintainingStatistics {
 		return "g=" + getNumberOfChoices() + ", bt=" + getNumberOfBacktracks() + ", bj=" + getNumberOfBackjumps() + ", bt_within_bj="
 				+ getNumberOfBacktracksWithinBackjumps() + ", mbt=" + getNumberOfBacktracksDueToRemnantMBTs() + ", cac=" + getNumberOfConflictsAfterClosing();
 	}
+	
+	default String getStatisticsCSV() {
+		return String.format("%d,%d,%d,%d,%d,%d", getNumberOfChoices(), getNumberOfBacktracks(), getNumberOfBackjumps(), getNumberOfBacktracksWithinBackjumps(), getNumberOfBacktracksDueToRemnantMBTs(), getNumberOfConflictsAfterClosing());
+	}
 
 	default void printStatistics(PrintStream out) {
 		out.println(getStatisticsString());

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/SolverMaintainingStatistics.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/SolverMaintainingStatistics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Siemens AG
+ * Copyright (c) 2017-2018 Siemens AG
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -38,10 +38,15 @@ public interface SolverMaintainingStatistics {
 	int getNumberOfBackjumps();
 
 	int getNumberOfBacktracksDueToRemnantMBTs();
+	
+	/**
+	 * @return the number of times the solver had to backtrack after closing unassigned atoms
+	 */
+	int getNumberOfConflictsAfterClosing();
 
 	default String getStatisticsString() {
 		return "g=" + getNumberOfChoices() + ", bt=" + getNumberOfBacktracks() + ", bj=" + getNumberOfBackjumps() + ", bt_within_bj="
-				+ getNumberOfBacktracksWithinBackjumps() + ", mbt=" + getNumberOfBacktracksDueToRemnantMBTs();
+				+ getNumberOfBacktracksWithinBackjumps() + ", mbt=" + getNumberOfBacktracksDueToRemnantMBTs() + ", cac=" + getNumberOfConflictsAfterClosing();
 	}
 
 	default void printStatistics(PrintStream out) {

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/SolverStatisticsTests.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/SolverStatisticsTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Siemens AG
+ * Copyright (c) 2017-2018 Siemens AG
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -37,24 +37,24 @@ public class SolverStatisticsTests extends AbstractSolverTests {
 	@Test
 	public void checkStatsStringZeroChoices() {
 		Solver solver = getInstance("a.");
-		collectAnswerSetsAndCheckStats(solver, 1, 0, 0, 0, 0, 0);
+		collectAnswerSetsAndCheckStats(solver, 1, 0, 0, 0, 0, 0, 0);
 	}
 
 	@Test
 	public void checkStatsStringOneChoice() {
 		Solver solver = getInstance("a :- not b. b :- not a.");
-		collectAnswerSetsAndCheckStats(solver, 2, 1, 1, 1, 1, 0);
+		collectAnswerSetsAndCheckStats(solver, 2, 1, 1, 1, 1, 0, 0);
 	}
 
 	private void collectAnswerSetsAndCheckStats(Solver solver, int expectedNumberOfAnswerSets, int expectedNumberOfGuesses, int expectedTotalNumberOfBacktracks,
-			int expectedNumberOfBacktracksWithinBackjumps, int expectedNumberOfBackjumps, int expectedNumberOfMBTs) {
+			int expectedNumberOfBacktracksWithinBackjumps, int expectedNumberOfBackjumps, int expectedNumberOfMBTs, int expectedNumberOfConflictsAfterClosing) {
 		Set<AnswerSet> answerSets = solver.collectSet();
 		assertEquals(expectedNumberOfAnswerSets, answerSets.size());
 		if (solver instanceof SolverMaintainingStatistics) {
 			SolverMaintainingStatistics solverMaintainingStatistics = (SolverMaintainingStatistics) solver;
 			assertEquals(
-					String.format("g=%d, bt=%d, bj=%d, bt_within_bj=%d, mbt=%d", expectedNumberOfGuesses, expectedTotalNumberOfBacktracks, expectedNumberOfBackjumps,
-							expectedNumberOfBacktracksWithinBackjumps, expectedNumberOfMBTs),
+					String.format("g=%d, bt=%d, bj=%d, bt_within_bj=%d, mbt=%d, cac=%d", expectedNumberOfGuesses, expectedTotalNumberOfBacktracks, expectedNumberOfBackjumps,
+							expectedNumberOfBacktracksWithinBackjumps, expectedNumberOfMBTs, expectedNumberOfConflictsAfterClosing),
 					solverMaintainingStatistics.getStatisticsString());
 		}
 	}


### PR DESCRIPTION
i.e. the number of times the solver had to backtrack after closing unassigned atoms.
Contributes to #113