### PR TITLE
Reactivate AlphaHeuristicTestAssumptions and fix bug in DependencyDrivenHeuristic

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/heuristics/DependencyDrivenHeuristic.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/heuristics/DependencyDrivenHeuristic.java
@@ -337,7 +337,7 @@ public class DependencyDrivenHeuristic implements BranchingHeuristic {
 	 * @return {@code true} iff: the NoGood is binary, and it has a head, and its tail is an atom representing a rule body.
 	 */
 	public static boolean isBodyNotHead(NoGood noGood, Predicate<? super Integer> isRuleBody) {
-		return noGood.isBinary() && noGood.hasHead() && isRuleBody.test(atomOf(1));
+		return noGood.isBinary() && noGood.hasHead() && isRuleBody.test(noGood.getAtom(1));
 	}
 
 	/**

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/heuristics/AlphaHeuristicTestAssumptions.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/heuristics/AlphaHeuristicTestAssumptions.java
@@ -47,8 +47,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Tests assumptions made by {@link AlphaHeuristic}. Even if these test cases do not test {@link AlphaHeuristic} directly, it will break if these test cases
- * break.
+ * Tests assumptions made by {@link DependencyDrivenHeuristic} and other domain-independent heuristics.
+ * Even if these test cases do not test {@link DependencyDrivenHeuristic} directly,
+ * it will break if these test cases break.
  * 
  * Copyright (c) 2017-2018 Siemens AG
  *

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/heuristics/AlphaHeuristicTestAssumptions.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/heuristics/AlphaHeuristicTestAssumptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Siemens AG
+ * Copyright (c) 2017-2018 Siemens AG
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -35,12 +35,12 @@ import at.ac.tuwien.kr.alpha.solver.NaiveNoGoodStore;
 import at.ac.tuwien.kr.alpha.solver.TestableChoiceManager;
 import at.ac.tuwien.kr.alpha.solver.WritableAssignment;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static at.ac.tuwien.kr.alpha.common.Literals.atomOf;
 import static org.junit.Assert.assertEquals;
@@ -50,7 +50,7 @@ import static org.junit.Assert.assertTrue;
  * Tests assumptions made by {@link AlphaHeuristic}. Even if these test cases do not test {@link AlphaHeuristic} directly, it will break if these test cases
  * break.
  * 
- * Copyright (c) 2017 Siemens AG
+ * Copyright (c) 2017-2018 Siemens AG
  *
  */
 public class AlphaHeuristicTestAssumptions {
@@ -60,7 +60,12 @@ public class AlphaHeuristicTestAssumptions {
 	
 	@Before
 	public void setUp() throws IOException {
-		String testProgram = "h :- b1, b2, not b3, not b4.";
+		String testProgram = ""
+				+ "b1."
+				+ "b2."
+				+ "{b3}."
+				+ "{b4}."
+				+ "h :- b1, b2, not b3, not b4.";
 		Program parsedProgram = new ProgramParser().parse(testProgram);
 		this.grounder = new NaiveGrounder(parsedProgram);
 		this.assignment = new ArrayAssignment();
@@ -68,13 +73,11 @@ public class AlphaHeuristicTestAssumptions {
 	}
 
 	@Test
-	@Ignore("Test strictly depends on generated NoGoods. Grounder optimisations change generated NoGoods.")
 	public void testNumbersOfNoGoods_GrounderIsAtomChoicePoint() {
 		testNumbersOfNoGoods(grounder::isAtomChoicePoint);
 	}
 
 	@Test
-	@Ignore("Test strictly depends on generated NoGoods. Grounder optimisations change generated NoGoods.")
 	public void testNumbersOfNoGoods_ChoiceManagerIsAtomChoice() {
 		testNumbersOfNoGoods(choiceManager::isAtomChoice);
 	}
@@ -107,9 +110,11 @@ public class AlphaHeuristicTestAssumptions {
 				other++;
 			}
 		}
+		
+		System.out.println(noGoods.stream().map(grounder::noGoodToString).collect(Collectors.joining(", ")));
 
-		assertEquals("Unexpected number of bodyNotHead nogoods", 1, bodyNotHead);
-		assertEquals("Unexpected number of bodyElementsNotBody nogoods", 1, bodyElementsNotBody);
+		assertEquals("Unexpected number of bodyNotHead nogoods", 5, bodyNotHead);
+		assertEquals("Unexpected number of bodyElementsNotBody nogoods", 5, bodyElementsNotBody);
 		assertGreaterThan("Unexpected number of nogoods without head", 4, noHead);
 
 		// there may be other nogoods (e.g. for ChoiceOn, ChoiceOff) which we do not care for here


### PR DESCRIPTION
Please reactivate `AlphaHeuristicTestAssumptions`, a set of test cases deactivated by 486ffdb1f4379d9bccf2dcedafa322d7175db062. These test cases are important for domain-independent heuristics to work correctly. For example, the test cases would have been able to detect a bug introduced by 211641771b0f24ac4725eed0ca9e3bd4a0355b71 and fixed by 2a2cb1cc68c72e736851543a774e33ea3f87f2f9 if they would have been enabled. The idea is to adapt the test cases (and the heuristics, if necessary) when something in the generation of nogoods changes.