### PR TITLE
Invert handling of literal polarity

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/Atom.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/Atom.java
@@ -72,15 +72,15 @@ public interface Atom extends Comparable<Atom> {
 	 * Creates a non-negated literal containing this atom
 	 */
 	default Literal toLiteral() {
-		return toLiteral(false);
+		return toLiteral(true);
 	}
 	
 	/**
-	 * Creates a literal containing this atom which will be negated if {@code negated} is {@code true}
-	 * @param negated
+	 * Creates a literal containing this atom which will be negated if {@code positive} is {@code false}
+	 * @param positive
 	 * @return
 	 */
-	Literal toLiteral(boolean negated);
+	Literal toLiteral(boolean positive);
 
 	@Override
 	default int compareTo(Atom o) {

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/BasicAtom.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/BasicAtom.java
@@ -97,8 +97,8 @@ public class BasicAtom implements Atom {
 	}
 	
 	@Override
-	public BasicLiteral toLiteral(boolean negated) {
-		return new BasicLiteral(this, negated);
+	public BasicLiteral toLiteral(boolean positive) {
+		return new BasicLiteral(this, positive);
 	}
 
 	@Override

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/BasicLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/BasicLiteral.java
@@ -42,8 +42,8 @@ import java.util.Set;
  */
 public class BasicLiteral extends Literal {
 	
-	public BasicLiteral(BasicAtom atom, boolean negated) {
-		super(atom, negated);
+	public BasicLiteral(BasicAtom atom, boolean positive) {
+		super(atom, positive);
 	}
 	
 	@Override
@@ -56,7 +56,7 @@ public class BasicLiteral extends Literal {
 	 */
 	@Override
 	public BasicLiteral negate() {
-		return new BasicLiteral(getAtom(), !negated);
+		return new BasicLiteral(getAtom(), !positive);
 	}
 
 	/**
@@ -64,7 +64,7 @@ public class BasicLiteral extends Literal {
 	 */
 	@Override
 	public BasicLiteral substitute(Substitution substitution) {
-		return new BasicLiteral(getAtom().substitute(substitution), negated);
+		return new BasicLiteral(getAtom().substitute(substitution), positive);
 	}
 
 	/**
@@ -74,7 +74,7 @@ public class BasicLiteral extends Literal {
 	 */
 	@Override
 	public Set<VariableTerm> getBindingVariables() {
-		if (negated) {
+		if (!positive) {
 			// Negative literal has no binding variables.
 			return Collections.emptySet();
 		}
@@ -92,7 +92,7 @@ public class BasicLiteral extends Literal {
 	 */
 	@Override
 	public Set<VariableTerm> getNonBindingVariables() {
-		if (!negated) {
+		if (positive) {
 			// Positive literal has only binding variables.
 			return Collections.emptySet();
 		}

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ComparisonAtom.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ComparisonAtom.java
@@ -77,8 +77,8 @@ public class ComparisonAtom implements Atom {
 	}
 
 	@Override
-	public ComparisonLiteral toLiteral(boolean negated) {
-		return new ComparisonLiteral(this, negated);
+	public ComparisonLiteral toLiteral(boolean positive) {
+		return new ComparisonLiteral(this, positive);
 	}
 
 	@Override

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ComparisonLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ComparisonLiteral.java
@@ -41,8 +41,8 @@ import java.util.*;
  */
 public class ComparisonLiteral extends FixedInterpretationLiteral {
 
-	public ComparisonLiteral(ComparisonAtom atom, boolean negated) {
-		super(atom, negated);
+	public ComparisonLiteral(ComparisonAtom atom, boolean positive) {
+		super(atom, positive);
 	}
 	
 	@Override
@@ -52,8 +52,8 @@ public class ComparisonLiteral extends FixedInterpretationLiteral {
 	
 	public boolean isNormalizedEquality() {
 		ComparisonOperator operator = getAtom().operator;
-		return (!negated && operator == ComparisonOperator.EQ)
-				|| (negated && operator == ComparisonOperator.NE);
+		return (positive && operator == ComparisonOperator.EQ)
+				|| (!positive && operator == ComparisonOperator.NE);
 	}
 
 	private boolean isLeftAssigning() {
@@ -69,7 +69,7 @@ public class ComparisonLiteral extends FixedInterpretationLiteral {
 	 */
 	@Override
 	public ComparisonLiteral negate() {
-		return new ComparisonLiteral(getAtom(), !negated);
+		return new ComparisonLiteral(getAtom(), !positive);
 	}
 
 	/**
@@ -77,7 +77,7 @@ public class ComparisonLiteral extends FixedInterpretationLiteral {
 	 */
 	@Override
 	public ComparisonLiteral substitute(Substitution substitution) {
-		return new ComparisonLiteral(getAtom().substitute(substitution), negated);
+		return new ComparisonLiteral(getAtom().substitute(substitution), positive);
 	}
 
 	@Override

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalAtom.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalAtom.java
@@ -97,8 +97,8 @@ public class ExternalAtom implements Atom {
 	}
 
 	@Override
-	public ExternalLiteral toLiteral(boolean negated) {
-		return new ExternalLiteral(this, negated);
+	public ExternalLiteral toLiteral(boolean positive) {
+		return new ExternalLiteral(this, positive);
 	}
 
 	@Override

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
@@ -41,8 +41,8 @@ import static java.util.Collections.emptyList;
  */
 public class ExternalLiteral extends FixedInterpretationLiteral {
 
-	public ExternalLiteral(ExternalAtom atom, boolean negated) {
-		super(atom, negated);
+	public ExternalLiteral(ExternalAtom atom, boolean positive) {
+		super(atom, positive);
 	}
 	
 	@Override
@@ -55,7 +55,7 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 	 */
 	@Override
 	public ExternalLiteral negate() {
-		return new ExternalLiteral(getAtom(), !negated);
+		return new ExternalLiteral(getAtom(), !positive);
 	}
 
 	/**
@@ -63,7 +63,7 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 	 */
 	@Override
 	public ExternalLiteral substitute(Substitution substitution) {
-		return new ExternalLiteral(getAtom().substitute(substitution), negated);
+		return new ExternalLiteral(getAtom().substitute(substitution), positive);
 	}
 
 	@Override
@@ -72,7 +72,7 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 		// and there are no binding variables (like for ordinary atoms).
 		// If the external atom is positive, then variables of output are binding.
 
-		if (negated) {
+		if (!positive) {
 			return Collections.emptySet();
 		}
 		
@@ -102,7 +102,7 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 		}
 
 		// If the external atom is negative, then all variables of input and output are non-binding.
-		if (negated) {
+		if (!positive) {
 			for (Term out : output) {
 				if (out instanceof VariableTerm) {
 					nonbindingVariables.add((VariableTerm) out);

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/FixedInterpretationLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/FixedInterpretationLiteral.java
@@ -38,8 +38,8 @@ import java.util.List;
  */
 public abstract class FixedInterpretationLiteral extends Literal {
 	
-	public FixedInterpretationLiteral(Atom atom, boolean negated) {
-		super(atom, negated);
+	public FixedInterpretationLiteral(Atom atom, boolean positive) {
+		super(atom, positive);
 	}
 	
 	public abstract List<Substitution> getSubstitutions(Substitution partialSubstitution);

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/Literal.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/Literal.java
@@ -43,11 +43,11 @@ import java.util.Set;
 public abstract class Literal {
 	
 	protected final Atom atom;
-	protected final boolean negated;
+	protected final boolean positive;
 	
-	public Literal(Atom atom, boolean negated) {
+	public Literal(Atom atom, boolean positive) {
 		this.atom = atom;
-		this.negated = negated;
+		this.positive = positive;
 	}
 
 	public Atom getAtom() {
@@ -55,7 +55,7 @@ public abstract class Literal {
 	}
 
 	public boolean isNegated() {
-		return negated;
+		return !positive;
 	}
 	
 	public abstract Literal negate();
@@ -89,7 +89,7 @@ public abstract class Literal {
 	
 	@Override
 	public String toString() {
-		return (negated ? "not " : "") + atom.toString();
+		return (positive ? "" : "not ") + atom.toString();
 	}
 
 	@Override
@@ -103,12 +103,12 @@ public abstract class Literal {
 
 		Literal that = (Literal) o;
 
-		return atom.equals(that.atom) && negated == that.negated;
+		return atom.equals(that.atom) && positive == that.positive;
 	}
 
 	@Override
 	public int hashCode() {
-		return 12 * atom.hashCode() + (negated ? 1 : 0);
+		return 12 * atom.hashCode() + (positive ? 1 : 0);
 	}
 
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/IndexedInstanceStorage.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/IndexedInstanceStorage.java
@@ -1,3 +1,30 @@
+/**
+ * Copyright (c) 2016-2018, the Alpha Team.
+ * All rights reserved.
+ *
+ * Additional changes made by Siemens.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.grounder;
 
 import at.ac.tuwien.kr.alpha.common.Predicate;
@@ -9,11 +36,11 @@ import java.util.*;
  * A storage for instances with a certain arity, where each position of the instance can be indexed.
  * This aids in matching and joining instances. An index can be added or removed at any time for a desired position of
  * all instances.
- * Copyright (c) 2016, the Alpha Team.
+ * Copyright (c) 2016-2018, the Alpha Team.
  */
 public class IndexedInstanceStorage {
 	private final Predicate predicate;
-	private final boolean negated;
+	private final boolean positive;
 
 	/**
 	 * A collection of all instances currently stored in this storage.
@@ -27,9 +54,9 @@ public class IndexedInstanceStorage {
 
 	private final ArrayList<Instance> recentlyAddedInstances = new ArrayList<>();
 
-	public IndexedInstanceStorage(Predicate predicate, boolean negated) {
+	public IndexedInstanceStorage(Predicate predicate, boolean positive) {
 		this.predicate = predicate;
-		this.negated = negated;
+		this.positive = positive;
 
 		// Create list of mappings, initialize to null.
 		while (indices.size() < predicate.getArity()) {
@@ -147,6 +174,6 @@ public class IndexedInstanceStorage {
 
 	@Override
 	public String toString() {
-		return (negated ? "-" : "+") + predicate;
+		return (positive ? "+" : "-") + predicate;
 	}
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
@@ -542,7 +542,7 @@ public class NaiveGrounder extends BridgedGrounder {
 			isFirst = false;
 		}
 		for (Atom bodyAtom : rule.getBodyAtomsNegative()) {
-			ret.append(groundLiteralToString(bodyAtom.toLiteral(true), substitution, isFirst));
+			ret.append(groundLiteralToString(bodyAtom.toLiteral(false), substitution, isFirst));
 			isFirst = false;
 		}
 		ret.append(".");

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/WorkingMemory.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/WorkingMemory.java
@@ -50,8 +50,8 @@ public class WorkingMemory {
 			return;
 		}
 
-		IndexedInstanceStorage pos = new IndexedInstanceStorage(predicate, false);
-		IndexedInstanceStorage neg = new IndexedInstanceStorage(predicate, true);
+		IndexedInstanceStorage pos = new IndexedInstanceStorage(predicate, true);
+		IndexedInstanceStorage neg = new IndexedInstanceStorage(predicate, false);
 		// Index all positions of the storage (may impair efficiency)
 		for (int i = 0; i < predicate.getArity(); i++) {
 			pos.addIndexPosition(i);

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/atoms/IntervalAtom.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/atoms/IntervalAtom.java
@@ -75,8 +75,8 @@ public class IntervalAtom implements Atom {
 	}
 	
 	@Override
-	public IntervalLiteral toLiteral(boolean negated) {
-		if (negated) {
+	public IntervalLiteral toLiteral(boolean positive) {
+		if (!positive) {
 			throw oops("IntervalLiteral cannot be negated");
 		}
 		return new IntervalLiteral(this);

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/atoms/IntervalLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/atoms/IntervalLiteral.java
@@ -46,7 +46,7 @@ import java.util.Set;
 public class IntervalLiteral extends FixedInterpretationLiteral {
 
 	public IntervalLiteral(IntervalAtom atom) {
-		super(atom, false);
+		super(atom, true);
 	}
 	
 	@Override

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/atoms/RuleAtom.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/atoms/RuleAtom.java
@@ -87,7 +87,7 @@ public class RuleAtom implements Atom {
 	}
 	
 	@Override
-	public Literal toLiteral(boolean negated) {
+	public Literal toLiteral(boolean positive) {
 		throw new UnsupportedOperationException("RuleAtom cannot be literalized");
 	}
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ParseTreeVisitor.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ParseTreeVisitor.java
@@ -318,11 +318,11 @@ public class ParseTreeVisitor extends ASPCore2BaseVisitor<Object> {
 		// naf_literal : NAF? (external_atom | classical_literal | builtin_atom);
 		boolean isCurrentLiteralNegated = ctx.NAF() != null;
 		if (ctx.builtin_atom() != null) {
-			return new ComparisonLiteral(visitBuiltin_atom(ctx.builtin_atom()), isCurrentLiteralNegated);
+			return new ComparisonLiteral(visitBuiltin_atom(ctx.builtin_atom()), !isCurrentLiteralNegated);
 		} else if (ctx.classical_literal() != null) {
-			return new BasicLiteral(visitClassical_literal(ctx.classical_literal()), isCurrentLiteralNegated);
+			return new BasicLiteral(visitClassical_literal(ctx.classical_literal()), !isCurrentLiteralNegated);
 		} else if (ctx.external_atom() != null) {
-			return new ExternalLiteral(visitExternal_atom(ctx.external_atom()), isCurrentLiteralNegated);
+			return new ExternalLiteral(visitExternal_atom(ctx.external_atom()), !isCurrentLiteralNegated);
 		}
 		throw notSupported(ctx);
 	}

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/transformation/ChoiceHeadToNormal.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/transformation/ChoiceHeadToNormal.java
@@ -92,11 +92,11 @@ public class ChoiceHeadToNormal implements ProgramTransformation {
 
 				// Construct two guessing rules.
 				List<Literal> guessingRuleBodyWithNegHead = new ArrayList<>(ruleBody);
-				guessingRuleBodyWithNegHead.add(new BasicAtom(head.getPredicate(), head.getTerms()).toLiteral(true));
+				guessingRuleBodyWithNegHead.add(new BasicAtom(head.getPredicate(), head.getTerms()).toLiteral(false));
 				additionalRules.add(new Rule(new DisjunctiveHead(Collections.singletonList(negHead)), guessingRuleBodyWithNegHead));
 
 				List<Literal> guessingRuleBodyWithHead = new ArrayList<>(ruleBody);
-				guessingRuleBodyWithHead.add(new BasicAtom(negPredicate, headTerms).toLiteral(true));
+				guessingRuleBodyWithHead.add(new BasicAtom(negPredicate, headTerms).toLiteral(false));
 				additionalRules.add(new Rule(new DisjunctiveHead(Collections.singletonList(head)), guessingRuleBodyWithHead));
 
 				// TODO: when cardinality constraints are possible, process the boundaries by adding a constraint with a cardinality check.

--- a/src/test/java/at/ac/tuwien/kr/alpha/AlphaTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/AlphaTest.java
@@ -244,7 +244,7 @@ public class AlphaTest {
 								new MethodPredicateInterpretation(this.getClass().getMethod("thinger", Thingy.class)),
 								singletonList(ConstantTerm.getInstance(thingy)),
 								emptyList()),
-								false
+								true
 							)
 						)
 				);

--- a/src/test/java/at/ac/tuwien/kr/alpha/grounder/IndexedInstanceStorageTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/grounder/IndexedInstanceStorageTest.java
@@ -1,3 +1,30 @@
+/**
+ * Copyright (c) 2016-2018, the Alpha Team.
+ * All rights reserved.
+ *
+ * Additional changes made by Siemens.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.grounder;
 
 import at.ac.tuwien.kr.alpha.common.Predicate;
@@ -14,15 +41,15 @@ import static org.junit.Assert.*;
 public class IndexedInstanceStorageTest {
 	@Test
 	public void testIndexedInstanceStorage() {
-		IndexedInstanceStorage storage = new IndexedInstanceStorage(Predicate.getInstance("p", 4), false);
+		IndexedInstanceStorage storage = new IndexedInstanceStorage(Predicate.getInstance("p", 4), true);
 		storage.addIndexPosition(0);
 		storage.addIndexPosition(2);
-		ConstantTerm t0 = ConstantTerm.getInstance("0");
-		ConstantTerm t1 = ConstantTerm.getInstance("1");
-		ConstantTerm t2 = ConstantTerm.getInstance("2");
-		ConstantTerm t3 = ConstantTerm.getInstance("3");
-		ConstantTerm t4 = ConstantTerm.getInstance("4");
-		ConstantTerm t5 = ConstantTerm.getInstance("5");
+		ConstantTerm<String> t0 = ConstantTerm.getInstance("0");
+		ConstantTerm<String> t1 = ConstantTerm.getInstance("1");
+		ConstantTerm<String> t2 = ConstantTerm.getInstance("2");
+		ConstantTerm<String> t3 = ConstantTerm.getInstance("3");
+		ConstantTerm<String> t4 = ConstantTerm.getInstance("4");
+		ConstantTerm<String> t5 = ConstantTerm.getInstance("5");
 
 		Instance badInst1 = new Instance(t1, t1, t0);
 		Instance badInst2 = new Instance(t5, t5, t5, t5, t5);

--- a/src/test/java/at/ac/tuwien/kr/alpha/grounder/SubstitutionTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/grounder/SubstitutionTest.java
@@ -121,7 +121,7 @@ public class SubstitutionTest {
 	private void substituteBasicAtomLiteral(boolean negated) {
 		Predicate p = Predicate.getInstance("p", 2);
 		BasicAtom atom = new BasicAtom(p, Arrays.asList(X, Y));
-		Literal literal = new BasicLiteral(atom, negated);
+		Literal literal = new BasicLiteral(atom, !negated);
 		Substitution substitution = new Substitution();
 		substitution.unifyTerms(X, A);
 		substitution.unifyTerms(Y, B);
@@ -148,7 +148,7 @@ public class SubstitutionTest {
 		Substitution substitution = new Substitution();
 		substitution.unifyTerms(X, A);
 		substitution.unifyTerms(Y, B);
-		String printedString = NaiveGrounder.groundLiteralToString(atom.toLiteral(negated), substitution, true);
+		String printedString = NaiveGrounder.groundLiteralToString(atom.toLiteral(!negated), substitution, true);
 		assertEquals((negated ? "not " : "") + "p(a, b)", printedString);
 	}
 


### PR DESCRIPTION
Globally replace `Literal.negated` by `Literal.positive` for clarity (e.g., it is more intuitive if `atom.toLiteral(true)` creates a positive literal than a negative one).