### PR TITLE
Fix error in performance output messages.

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
@@ -141,7 +141,7 @@ public class DefaultSolver extends AbstractSolver implements SolverMaintainingSt
 				decisionsLast = currentNumberOfChoices;
 				float overallTime = (currentTime - timeOnEntry) / 1000.0f;
 				float decisionsPerSec = currentNumberOfChoices / overallTime;
-				LOGGER.info("Overall performance: {} decision in {}s or {} decisions per sec. Overall replayed assignments: {}.", currentNumberOfChoices, currentTime - timeOnEntry, decisionsPerSec, ((TrailAssignment)assignment).replayCounter);
+				LOGGER.info("Overall performance: {} decisions in {}s or {} decisions per sec. Overall replayed assignments: {}.", currentNumberOfChoices, overallTime, decisionsPerSec, ((TrailAssignment)assignment).replayCounter);
 			}
 			ConflictCause conflictCause = store.propagate();
 			didChange |= store.didPropagate();


### PR DESCRIPTION
Solves part of #113:
E.g. message

>Overall performance: 733 decision in 8003s or 91.59065 decisions per sec. Overall replayed assignments: 152. 

is now 

>Overall performance: 733 decisions in 8.003s or 91.59065 decisions per sec. Overall replayed assignments: 152. 