### PR TITLE
Immediately ground already-ground rules by default

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/common/Rule.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/Rule.java
@@ -147,7 +147,7 @@ public class Rule {
 	}
 
 	public boolean isGround() {
-		if (!head.isNormal()) {
+		if (head != null && !head.isNormal()) {
 			throw oops("Called isGround on non-normal rule");
 		}
 		if (!isConstraint() && !((DisjunctiveHead)head).isGround()) {

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
@@ -39,9 +39,6 @@ import at.ac.tuwien.kr.alpha.grounder.atoms.RuleAtom;
 import at.ac.tuwien.kr.alpha.grounder.bridges.Bridge;
 import at.ac.tuwien.kr.alpha.grounder.structure.AnalyzeUnjustified;
 import at.ac.tuwien.kr.alpha.grounder.structure.ProgramAnalysis;
-import at.ac.tuwien.kr.alpha.grounder.transformation.ChoiceHeadToNormal;
-import at.ac.tuwien.kr.alpha.grounder.transformation.IntervalTermToIntervalAtom;
-import at.ac.tuwien.kr.alpha.grounder.transformation.VariableEqualityRemoval;
 import at.ac.tuwien.kr.alpha.grounder.transformation.*;
 import at.ac.tuwien.kr.alpha.solver.ThriceTruth;
 import org.apache.commons.lang3.tuple.Pair;
@@ -79,6 +76,14 @@ public class NaiveGrounder extends BridgedGrounder implements ProgramAnalyzingGr
 	private int maxAtomIdBeforeGroundingNewNoGoods = -1;
 	private boolean disableInstanceRemoval;
 	private boolean useCountingGridNormalization;
+	
+	/**
+	 * If this configuration parameter is {@code true} (which it is by default),
+	 * the grounder stops grounding a rule if it contains a positive body atom which is not
+	 * yet true. Is currently used only internally, but might be used for grounder heuristics
+	 * and also set from the outside in the future.
+	 */
+	private boolean stopBindingAtNonTruePositiveBody = true;
 
 	public NaiveGrounder(Program program, AtomStore atomStore, Bridge... bridges) {
 		this(program, atomStore, p -> true, false, bridges);
@@ -292,7 +297,7 @@ public class NaiveGrounder extends BridgedGrounder implements ProgramAnalyzingGr
 		for (NonGroundRule nonGroundRule : fixedRules) {
 			// Generate NoGoods for all rules that have a fixed grounding.
 			Literal[] groundingOrder = nonGroundRule.groundingOrder.getFixedGroundingOrder();
-			List<Substitution> substitutions = bindNextAtomInRule(groundingOrder, 0, new Substitution(), null);
+			List<Substitution> substitutions = bindNextAtomInRuleContinuingBindingAtNonTruePositiveBody(nonGroundRule, groundingOrder, 0, new Substitution(), null);
 			for (Substitution substitution : substitutions) {
 				registry.register(noGoodGenerator.generateNoGoodsFromGroundSubstitution(nonGroundRule, substitution), groundNogoods);
 			}
@@ -377,6 +382,16 @@ public class NaiveGrounder extends BridgedGrounder implements ProgramAnalyzingGr
 	public int register(NoGood noGood) {
 		return registry.register(noGood);
 	}
+	
+	private List<Substitution> bindNextAtomInRuleContinuingBindingAtNonTruePositiveBody(NonGroundRule nonGroundRule, Literal[] groundingOrder, int orderPosition, Substitution partialSubstitution, Assignment currentAssignment) {
+		boolean oldStopBindingAtNonTruePositiveBody = stopBindingAtNonTruePositiveBody;
+		if (nonGroundRule.getRule().isGround()) {
+			stopBindingAtNonTruePositiveBody = false;
+		}
+		List<Substitution> substitutions = bindNextAtomInRule(groundingOrder, 0, new Substitution(), null);
+		stopBindingAtNonTruePositiveBody = oldStopBindingAtNonTruePositiveBody;
+		return substitutions;
+	}
 
 	private List<Substitution> bindNextAtomInRule(Literal[] groundingOrder, int orderPosition, Substitution partialSubstitution, Assignment currentAssignment) {
 		if (orderPosition == groundingOrder.length) {
@@ -416,7 +431,7 @@ public class NaiveGrounder extends BridgedGrounder implements ProgramAnalyzingGr
 				return bindNextAtomInRule(groundingOrder, orderPosition + 1, partialSubstitution, currentAssignment);
 			}
 
-			if (!workingMemory.get(currentAtom.getPredicate(), true).containsInstance(new Instance(substitute.getTerms()))) {
+			if (stopBindingAtNonTruePositiveBody  && !workingMemory.get(currentAtom.getPredicate(), true).containsInstance(new Instance(substitute.getTerms()))) {
 				// Generate no variable substitution.
 				return emptyList();
 			}
@@ -453,8 +468,12 @@ public class NaiveGrounder extends BridgedGrounder implements ProgramAnalyzingGr
 		IndexedInstanceStorage storage = workingMemory.get(currentAtom.getPredicate(), true);
 		Collection<Instance> instances;
 		if (partialSubstitution.isEmpty()) {
-			// No variables are bound, but first atom in the body became recently true, consider all instances now.
-			instances = storage.getAllInstances();
+			if (currentLiteral.isGround()) {
+				instances = singletonList(new Instance(currentLiteral.getTerms()));
+			} else {
+				// No variables are bound, but first atom in the body became recently true, consider all instances now.
+				instances = storage.getAllInstances();
+			}
 		} else {
 			instances = storage.getInstancesFromPartiallyGroundAtom(substitute);
 		}

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/NonGroundRule.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/NonGroundRule.java
@@ -45,7 +45,7 @@ import static at.ac.tuwien.kr.alpha.Util.oops;
  * Copyright (c) 2017-2018, the Alpha Team.
  */
 public class NonGroundRule {
-	private static final IntIdGenerator ID_GENERATOR = new IntIdGenerator();
+	static final IntIdGenerator ID_GENERATOR = new IntIdGenerator();
 
 	private final int ruleId;
 	private final Rule rule;

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/RuleGroundingOrder.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/RuleGroundingOrder.java
@@ -56,7 +56,7 @@ public class RuleGroundingOrder {
 	private final NonGroundRule nonGroundRule;
 	private HashMap<Literal, Literal[]> groundingOrder;
 	private HashMap<Literal, Float> literalSelectivity;
-	private LinkedList<Literal> startingLiterals;
+	private List<Literal> startingLiterals;
 
 	private final boolean fixedGroundingInstantiation;
 	private Literal[] fixedGroundingOrder;
@@ -83,6 +83,13 @@ public class RuleGroundingOrder {
 	private boolean computeStartingLiterals() {
 		LinkedHashSet<Literal> fixedStartingLiterals = new LinkedHashSet<>();
 		LinkedHashSet<Literal> ordinaryStartingLiterals = new LinkedHashSet<>();
+		
+		// If the rule is ground, every body literal is a starting literal and the ground instantiation is fixed.
+		if (nonGroundRule.getRule().isGround()) {
+			startingLiterals = new LinkedList<>(nonGroundRule.getBodyLiterals());
+			return true;
+		}
+		
 		// Check each literal in the rule body whether it is eligible.
 		for (Literal literal : nonGroundRule.getBodyLiterals()) {
 			// Only literals that need no variables already bound can start grounding.

--- a/src/test/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounderTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounderTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2018 Siemens AG
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package at.ac.tuwien.kr.alpha.grounder;
+
+import at.ac.tuwien.kr.alpha.common.AtomStore;
+import at.ac.tuwien.kr.alpha.common.AtomStoreImpl;
+import at.ac.tuwien.kr.alpha.common.NoGood;
+import at.ac.tuwien.kr.alpha.common.Program;
+import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
+import at.ac.tuwien.kr.alpha.solver.TrailAssignment;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests {@link NaiveGrounder}
+ */
+public class NaiveGrounderTest {
+	private static final ProgramParser PARSER = new ProgramParser();
+	
+	/**
+	 * Asserts that a ground rule whose positive body is not satisfied by the empty assignment
+	 * is grounded immediately.
+	 */
+	@Test
+	public void groundRulesAlreadyGround() {
+		Program program = PARSER.parse("a :- not b. "
+				+ "b :- not a. "
+				+ "c :- b.");
+		
+		AtomStore atomStore = new AtomStoreImpl();
+		Grounder grounder = GrounderFactory.getInstance("naive", program, atomStore);
+		Map<Integer, NoGood> noGoods = grounder.getNoGoods(new TrailAssignment(atomStore));
+		Set<String> strNoGoods = noGoods.values().stream().map(atomStore::noGoodToString).collect(Collectors.toSet());
+		expectContains(strNoGoods, "*{-(a), +(_R_(\"0\",\"{}\"))}");
+		expectContains(strNoGoods, "*{-(b), +(_R_(\"1\",\"{}\"))}");
+		expectContains(strNoGoods, "*{-(c), +(_R_(\"2\",\"{}\"))}");
+	}
+	
+	/**
+	 * Asserts that a ground constraint whose positive body is not satisfied by the empty assignment
+	 * is grounded immediately.
+	 */
+	@Test
+	public void groundConstraintAlreadyGround() {
+		Program program = PARSER.parse("a :- not b. "
+				+ "b :- not a. "
+				+ ":- b.");
+		
+		AtomStore atomStore = new AtomStoreImpl();
+		Grounder grounder = GrounderFactory.getInstance("naive", program, atomStore);
+		Map<Integer, NoGood> noGoods = grounder.getNoGoods(new TrailAssignment(atomStore));
+		Set<String> strNoGoods = noGoods.values().stream().map(atomStore::noGoodToString).collect(Collectors.toSet());
+		System.out.println(strNoGoods);
+		expectContains(strNoGoods, "*{-(a), +(_R_(\"0\",\"{}\"))}");
+		expectContains(strNoGoods, "*{-(b), +(_R_(\"1\",\"{}\"))}");
+		expectContains(strNoGoods, "{+(b)}");
+	}
+
+	private void expectContains(Collection<String> strings, String string) {
+		assertTrue("Collection of strings does not contain \"" + string + "\"", strings.contains(string));
+	}
+
+}


### PR DESCRIPTION
Immediately ground already-ground rules by default by

- not stopping grounding a rule if a positive body atom is encountered that is not yet true (currently only for fully ground rules, but configurable),
- substituting ground atoms by themselves in this case, and
- considering all body literals as starting literals for the grounder in case a rule is fully ground.

Closes #149 