### PR TITLE
Evaluate arithmetic terms before storing ground atoms

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/Alpha.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/Alpha.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2018, the Alpha Team.
+ * Copyright (c) 2017-2019, the Alpha Team.
  * All rights reserved.
  * 
  * Additional changes made by Siemens.
@@ -219,7 +219,7 @@ public class Alpha {
 	}
 
 	public Stream<AnswerSet> solve() {
-		AtomStore atomStore = new AtomStoreImpl();
+		AtomStore atomStore = new AtomStoreImpl(debug);
 		Grounder grounder = GrounderFactory.getInstance(grounderName, program, atomStore);
 		Solver solver = SolverFactory.getInstance(solverName, storeName, atomStore, grounder, new Random(seed), BranchingHeuristicFactory.Heuristic.NAIVE, debug, false);
 		return solver.stream();

--- a/src/main/java/at/ac/tuwien/kr/alpha/Main.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/Main.java
@@ -226,7 +226,7 @@ public class Main {
 			bailOut("Failed to parse program.", e);
 		}
 
-		final AtomStore atomStore = new AtomStoreImpl();
+		final AtomStore atomStore = new AtomStoreImpl(debugInternalChecks);
 		final Grounder grounder = GrounderFactory.getInstance(
 			commandLine.getOptionValue(OPT_GROUNDER, DEFAULT_GROUNDER), program, atomStore, filter, normalizationUseGrid
 		);

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/AtomStore.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/AtomStore.java
@@ -1,6 +1,34 @@
+/**
+ * Copyright (c) 2016-2019, the Alpha Team.
+ * All rights reserved.
+ *
+ * Additional changes made by Siemens.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.common;
 
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
+import at.ac.tuwien.kr.alpha.common.terms.ArithmeticTerm;
 
 import java.util.Iterator;
 
@@ -38,6 +66,14 @@ public interface AtomStore {
 	 * @return the int representing the Atom object.
 	 */
 	int get(Atom atom);
+	
+	/**
+	 * Evaluates all {@link ArithmeticTerm}s in {@code groundAtom} before calling {@link #putIfAbsent(Atom)}.
+	 * The terms inside the atom are modified directly (TODO: change this, cf. issue #150)
+	 * @param groundAtom
+	 * @return the integer ID of the ground atom, possibly newly assigned
+	 */
+	int evaluateArithmeticTermsAndPutIfAbsent(Atom groundAtom);
 
 	/**
 	 * If the given ground atom is not already stored, associates it with a new integer (ID) and stores it, else

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/terms/ArithmeticTerm.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/terms/ArithmeticTerm.java
@@ -1,3 +1,30 @@
+/**
+ * Copyright (c) 2017-2019, the Alpha Team.
+ * All rights reserved.
+ * 
+ * Additional changes made by Siemens.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.common.terms;
 
 import at.ac.tuwien.kr.alpha.common.Interner;
@@ -10,7 +37,7 @@ import java.util.List;
 
 /**
  * This class represents an arithmetic expression occurring as a term.
- * Copyright (c) 2017, the Alpha Team.
+ * Copyright (c) 2017-2019, the Alpha Team.
  */
 public class ArithmeticTerm extends Term {
 	private static final Interner<ArithmeticTerm> INTERNER = new Interner<>();
@@ -191,6 +218,12 @@ public class ArithmeticTerm extends Term {
 		@Override
 		public Term renameVariables(String renamePrefix) {
 			return getInstance(left.renameVariables(renamePrefix));
+		}
+		
+		@Override
+		public Term normalizeVariables(String renamePrefix, RenameCounter counter) {
+			Term normalizedLeft = left.normalizeVariables(renamePrefix, counter);
+			return MinusTerm.getInstance(normalizedLeft);
 		}
 
 		@Override

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/NoGoodGenerator.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/NoGoodGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2018, the Alpha Team.
+ * Copyright (c) 2017-2019, the Alpha Team.
  * All rights reserved.
  * 
  * Additional changes made by Siemens.
@@ -45,7 +45,7 @@ import static java.util.Collections.singletonList;
 
 /**
  * Class to generate ground NoGoods out of non-ground rules and grounding substitutions.
- * Copyright (c) 2017-2018, the Alpha Team.
+ * Copyright (c) 2017-2019, the Alpha Team.
  */
 public class NoGoodGenerator {
 	private final AtomStore atomStore;
@@ -94,7 +94,7 @@ public class NoGoodGenerator {
 		}
 
 		final int bodyRepresentingLiteral = atomToLiteral(atomStore.putIfAbsent(bodyAtom));
-		final int headLiteral = atomToLiteral(atomStore.putIfAbsent(nonGroundRule.getHeadAtom().substitute(substitution)));
+		final int headLiteral = atomToLiteral(atomStore.evaluateArithmeticTermsAndPutIfAbsent(nonGroundRule.getHeadAtom().substitute(substitution)));
 
 		final List<NoGood> result = new ArrayList<>();
 
@@ -139,7 +139,7 @@ public class NoGoodGenerator {
 				continue;
 			}
 
-			bodyLiteralsNegative.add(atomToLiteral(atomStore.putIfAbsent(groundAtom)));
+			bodyLiteralsNegative.add(atomToLiteral(atomStore.evaluateArithmeticTermsAndPutIfAbsent(groundAtom)));
 		}
 		return bodyLiteralsNegative;
 	}
@@ -174,7 +174,7 @@ public class NoGoodGenerator {
 				return null;
 			}
 
-			bodyLiteralsPositive.add(atomToLiteral(atomStore.putIfAbsent(groundAtom)));
+			bodyLiteralsPositive.add(atomToLiteral(atomStore.evaluateArithmeticTermsAndPutIfAbsent(groundAtom)));
 		}
 		return bodyLiteralsPositive;
 	}

--- a/src/test/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounderTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounderTest.java
@@ -55,7 +55,7 @@ public class NaiveGrounderTest {
 				+ "b :- not a. "
 				+ "c :- b.");
 		
-		AtomStore atomStore = new AtomStoreImpl();
+		AtomStore atomStore = new AtomStoreImpl(true);
 		Grounder grounder = GrounderFactory.getInstance("naive", program, atomStore);
 		Map<Integer, NoGood> noGoods = grounder.getNoGoods(new TrailAssignment(atomStore));
 		int litCNeg = Literals.atomToLiteral(atomStore.get(new BasicAtom(Predicate.getInstance("c", 0))), false);
@@ -75,7 +75,7 @@ public class NaiveGrounderTest {
 				+ "c :- b. "
 				+ "d :- b, c. ");
 		
-		AtomStore atomStore = new AtomStoreImpl();
+		AtomStore atomStore = new AtomStoreImpl(true);
 		Grounder grounder = GrounderFactory.getInstance("naive", program, atomStore);
 		Map<Integer, NoGood> noGoods = grounder.getNoGoods(new TrailAssignment(atomStore));
 		int litANeg = Literals.atomToLiteral(atomStore.get(new BasicAtom(Predicate.getInstance("a", 0))), false);
@@ -98,7 +98,7 @@ public class NaiveGrounderTest {
 				+ "b :- not a. "
 				+ ":- b.");
 		
-		AtomStore atomStore = new AtomStoreImpl();
+		AtomStore atomStore = new AtomStoreImpl(true);
 		Grounder grounder = GrounderFactory.getInstance("naive", program, atomStore);
 		Map<Integer, NoGood> noGoods = grounder.getNoGoods(new TrailAssignment(atomStore));
 		int litB = Literals.atomToLiteral(atomStore.get(new BasicAtom(Predicate.getInstance("b", 0))));

--- a/src/test/java/at/ac/tuwien/kr/alpha/grounder/NoGoodGeneratorTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/grounder/NoGoodGeneratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 Siemens AG
+ * Copyright (c) 2018-2019 Siemens AG
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -63,7 +63,7 @@ public class NoGoodGeneratorTest {
 				+ "nq(a,b) :- not q(a,b).");
 		
 		Rule rule = program.getRules().get(1);
-		AtomStore atomStore = new AtomStoreImpl();
+		AtomStore atomStore = new AtomStoreImpl(true);
 		Grounder grounder = GrounderFactory.getInstance("naive", program, atomStore);
 		NoGoodGenerator noGoodGenerator = ((NaiveGrounder)grounder).noGoodGenerator;
 		NonGroundRule nonGroundRule = NonGroundRule.constructNonGroundRule(rule);

--- a/src/test/java/at/ac/tuwien/kr/alpha/grounder/structure/AnalyzeUnjustifiedTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/grounder/structure/AnalyzeUnjustifiedTest.java
@@ -1,3 +1,30 @@
+/**
+ * Copyright (c) 2018-2019, the Alpha Team.
+ * All rights reserved.
+ * 
+ * Additional changes made by Siemens.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.grounder.structure;
 
 import at.ac.tuwien.kr.alpha.common.AtomStore;
@@ -36,7 +63,7 @@ public class AnalyzeUnjustifiedTest {
 			"nr :- not r." +
 			":- not p(5).";
 		Program parsedProgram = parser.parse(program);
-		AtomStore atomStore = new AtomStoreImpl();
+		AtomStore atomStore = new AtomStoreImpl(true);
 		NaiveGrounder grounder = new NaiveGrounder(parsedProgram, atomStore);
 		grounder.getNoGoods(null);
 		TrailAssignment assignment = new TrailAssignment(atomStore);
@@ -61,7 +88,7 @@ public class AnalyzeUnjustifiedTest {
 			"{s(1,2)}." +
 			":- not p(1).";
 		Program parsedProgram = parser.parse(program);
-		AtomStore atomStore = new AtomStoreImpl();
+		AtomStore atomStore = new AtomStoreImpl(true);
 		NaiveGrounder grounder = new NaiveGrounder(parsedProgram, atomStore);
 		grounder.getNoGoods(null);
 		TrailAssignment assignment = new TrailAssignment(atomStore);
@@ -98,7 +125,7 @@ public class AnalyzeUnjustifiedTest {
 			"p(X) :- p(Y), s(Y,X)." +
 			":- not p(c).";
 		Program parsedProgram = parser.parse(program);
-		AtomStore atomStore = new AtomStoreImpl();
+		AtomStore atomStore = new AtomStoreImpl(true);
 		NaiveGrounder grounder = new NaiveGrounder(parsedProgram, atomStore);
 		grounder.getNoGoods(null);
 		TrailAssignment assignment = new TrailAssignment(atomStore);

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/AbstractSolverTests.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/AbstractSolverTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, the Alpha Team.
+ * Copyright (c) 2017-2019, the Alpha Team.
  * All rights reserved.
  *
  * Additional changes made by Siemens.
@@ -152,7 +152,7 @@ public abstract class AbstractSolverTests {
 	}
 
 	protected Solver getInstance(Program program) {
-		AtomStore atomStore = new AtomStoreImpl();
+		AtomStore atomStore = new AtomStoreImpl(true);
 		return getInstance(atomStore, GrounderFactory.getInstance(grounderName, program, atomStore));
 	}
 

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/AggregatesTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/AggregatesTest.java
@@ -164,7 +164,7 @@ public abstract class AggregatesTest extends AbstractSolverTests {
 	
 	@Override
 	protected Solver getInstance(Program program) {
-		AtomStore atomStore = new AtomStoreImpl();
+		AtomStore atomStore = new AtomStoreImpl(true);
 		return getInstance(atomStore, GrounderFactory.getInstance(grounderName, program, atomStore, p->true, useCountingGridNormalization()));
 	}
 	

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/ChoiceManagerTests.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/ChoiceManagerTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Siemens AG
+ * Copyright (c) 2017-2019 Siemens AG
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -51,7 +51,7 @@ public class ChoiceManagerTests extends AbstractSolverTests {
 	public void setUp() throws IOException {
 		String testProgram = "h :- b1, b2, not b3, not b4.";
 		Program parsedProgram = new ProgramParser().parse(testProgram);
-		this.atomStore = new AtomStoreImpl();
+		this.atomStore = new AtomStoreImpl(true);
 		this.grounder = new NaiveGrounder(parsedProgram, atomStore);
 		WritableAssignment assignment = new TrailAssignment(atomStore);
 		NoGoodStore store = new NoGoodStoreAlphaRoaming(assignment);

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/NaiveNoGoodStoreTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/NaiveNoGoodStoreTest.java
@@ -1,3 +1,30 @@
+/**
+ * Copyright (c) 2017-2019, the Alpha Team.
+ * All rights reserved.
+ *
+ * Additional changes made by Siemens.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.solver;
 
 import at.ac.tuwien.kr.alpha.common.*;
@@ -12,7 +39,7 @@ import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.*;
 import static org.junit.Assert.*;
 
 /**
- * Copyright (c) 2017, the Alpha Team.
+ * Copyright (c) 2017-2019, the Alpha Team.
  */
 public class NaiveNoGoodStoreTest {
 	private final AtomStore atomStore;
@@ -20,7 +47,7 @@ public class NaiveNoGoodStoreTest {
 	private final NaiveNoGoodStore store;
 
 	public NaiveNoGoodStoreTest() {
-		atomStore = new AtomStoreImpl();
+		atomStore = new AtomStoreImpl(true);
 		assignment = new TrailAssignment(atomStore);
 		store = new NaiveNoGoodStore(assignment);
 	}

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/NoGoodStoreAlphaRoamingTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/NoGoodStoreAlphaRoamingTest.java
@@ -1,3 +1,30 @@
+/**
+ * Copyright (c) 2017-2019, the Alpha Team.
+ * All rights reserved.
+ *
+ * Additional changes made by Siemens.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.solver;
 
 import at.ac.tuwien.kr.alpha.common.*;
@@ -12,7 +39,7 @@ import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.*;
 import static org.junit.Assert.*;
 
 /**
- * Copyright (c) 2017, the Alpha Team.
+ * Copyright (c) 2017-2019, the Alpha Team.
  */
 public class NoGoodStoreAlphaRoamingTest {
 
@@ -21,7 +48,7 @@ public class NoGoodStoreAlphaRoamingTest {
 	private final NoGoodStoreAlphaRoaming store;
 
 	public NoGoodStoreAlphaRoamingTest() {
-		atomStore = new AtomStoreImpl();
+		atomStore = new AtomStoreImpl(true);
 		AtomStoreTest.fillAtomStore(atomStore, 200);
 		assignment = new TrailAssignment(atomStore);
 		assignment.growForMaxAtomId();

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/SolverTests.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/SolverTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, the Alpha Team.
+ * Copyright (c) 2016-2019, the Alpha Team.
  * All rights reserved.
  * 
  * Additional changes made by Siemens.
@@ -726,13 +726,13 @@ public class SolverTests extends AbstractSolverTests {
 
 	@Test
 	public void dummyGrounder() {
-		AtomStore atomStore = new AtomStoreImpl();
+		AtomStore atomStore = new AtomStoreImpl(true);
 		TestCase.assertEquals(DummyGrounder.EXPECTED, getInstance(atomStore, new DummyGrounder(atomStore)).collectSet());
 	}
 
 	@Test
 	public void choiceGrounder() {
-		AtomStore atomStore = new AtomStoreImpl();
+		AtomStore atomStore = new AtomStoreImpl(true);
 		TestCase.assertEquals(ChoiceGrounder.EXPECTED, getInstance(atomStore, new ChoiceGrounder(atomStore)).collectSet());
 	}
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/TrailAssignmentTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/TrailAssignmentTest.java
@@ -1,3 +1,30 @@
+/**
+ * Copyright (c) 2018-2019, the Alpha Team.
+ * All rights reserved.
+ * 
+ * Additional changes made by Siemens.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.solver;
 
 import at.ac.tuwien.kr.alpha.common.*;
@@ -13,13 +40,13 @@ import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.*;
 import static org.junit.Assert.*;
 
 /**
- * Copyright (c) 2018, the Alpha Team.
+ * Copyright (c) 2018-2019, the Alpha Team.
  */
 public class TrailAssignmentTest {
 	private final TrailAssignment assignment;
 
 	public TrailAssignmentTest() {
-		AtomStore atomStore = new AtomStoreImpl();
+		AtomStore atomStore = new AtomStoreImpl(true);
 		AtomStoreTest.fillAtomStore(atomStore, 20);
 		assignment = new TrailAssignment(atomStore);
 	}

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/heuristics/AlphaHeuristicTestAssumptions.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/heuristics/AlphaHeuristicTestAssumptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2018 Siemens AG
+ * Copyright (c) 2017-2019 Siemens AG
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -71,7 +71,7 @@ public class AlphaHeuristicTestAssumptions {
 				+ "{b4}."
 				+ "h :- b1, b2, not b3, not b4.";
 		Program parsedProgram = new ProgramParser().parse(testProgram);
-		this.atomStore = new AtomStoreImpl();
+		this.atomStore = new AtomStoreImpl(true);
 		this.grounder = new NaiveGrounder(parsedProgram, atomStore);
 		this.assignment = new TrailAssignment(atomStore);
 		this.choiceManager = new TestableChoiceManager(assignment, new NaiveNoGoodStore(assignment));

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/heuristics/BerkMinTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/heuristics/BerkMinTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2017 Siemens AG
+ * Copyright (c) 2016-2019 Siemens AG
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests {@link BerkMin}.
  * 
- * Copyright (c) 2016 Siemens AG
+ * Copyright (c) 2016-2019 Siemens AG
  *
  */
 public class BerkMinTest {
@@ -58,7 +58,7 @@ public class BerkMinTest {
 	
 	@Before
 	public void setUp() {
-		AtomStore atomStore = new AtomStoreImpl();
+		AtomStore atomStore = new AtomStoreImpl(true);
 		AtomStoreTest.fillAtomStore(atomStore, 2);
 		WritableAssignment assignment = new TrailAssignment(atomStore);
 		assignment.growForMaxAtomId();

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/learning/FirstUIPPriorityQueueTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/learning/FirstUIPPriorityQueueTest.java
@@ -1,3 +1,30 @@
+/**
+ * Copyright (c) 2016-2019, the Alpha Team.
+ * All rights reserved.
+ *
+ * Additional changes made by Siemens.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.solver.learning;
 
 import at.ac.tuwien.kr.alpha.common.Assignment;
@@ -14,14 +41,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Copyright (c) 2016, the Alpha Team.
+ * Copyright (c) 2016-2019, the Alpha Team.
  */
 public class FirstUIPPriorityQueueTest {
 	private final AtomStore atomStore;
 	private final WritableAssignment assignment;
 
 	public FirstUIPPriorityQueueTest() {
-		atomStore = new AtomStoreImpl();
+		atomStore = new AtomStoreImpl(true);
 		assignment = new TrailAssignment(atomStore);
 	}
 

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/learning/GroundConflictNoGoodLearnerTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/learning/GroundConflictNoGoodLearnerTest.java
@@ -1,3 +1,30 @@
+/**
+ * Copyright (c) 2016-2019, the Alpha Team.
+ * All rights reserved.
+ *
+ * Additional changes made by Siemens.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.solver.learning;
 
 import at.ac.tuwien.kr.alpha.common.AtomStore;
@@ -12,7 +39,7 @@ import static at.ac.tuwien.kr.alpha.common.NoGoodTest.fromOldLiterals;
 import static org.junit.Assert.*;
 
 /**
- * Copyright (c) 2016, the Alpha Team.
+ * Copyright (c) 2016-2019, the Alpha Team.
  */
 public class GroundConflictNoGoodLearnerTest {
 
@@ -20,7 +47,7 @@ public class GroundConflictNoGoodLearnerTest {
 	private final NoGoodStore store;
 
 	public GroundConflictNoGoodLearnerTest() {
-		AtomStore atomStore = new AtomStoreImpl();
+		AtomStore atomStore = new AtomStoreImpl(true);
 		AtomStoreTest.fillAtomStore(atomStore, 20);
 		this.assignment = new TrailAssignment(atomStore);
 		this.assignment.growForMaxAtomId();


### PR DESCRIPTION
Contributes to fixing of #159 together with #160, but does not fully fix it. See [comment there](https://github.com/alpha-asp/Alpha/issues/159#issuecomment-457239549).