### PR TITLE
Fix error in performance logs

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
@@ -96,10 +96,10 @@ public class DefaultSolver extends AbstractSolver implements SolverMaintainingSt
 	@Override
 	protected boolean tryAdvance(Consumer<? super AnswerSet> action) {
 		boolean didChange = false;
-		performanceLog.initializeIfNotInitialized();
 
 		// Initially, get NoGoods from grounder.
 		if (initialize) {
+			performanceLog.initialize();
 			Map<Integer, NoGood> obtained = grounder.getNoGoods(assignment);
 			didChange = !obtained.isEmpty();
 			if (!ingest(obtained)) {

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
@@ -77,9 +77,9 @@ public class DefaultSolver extends AbstractSolver implements SolverMaintainingSt
 	private final boolean disableJustifications;
 	private boolean disableJustificationAfterClosing = true;	// Keep disabled for now, case not fully worked out yet.
 
-	private Long timeFirstEntry = null;
-	private Long timeLastPerformanceLog = null;
-	int numberOfChoicesLastPerformanceLog = 0;
+	private Long timeFirstEntry;
+	private Long timeLastPerformanceLog;
+	int numberOfChoicesLastPerformanceLog;
 
 	public DefaultSolver(AtomStore atomStore, Grounder grounder, NoGoodStore store, WritableAssignment assignment, Random random, Heuristic branchingHeuristic, boolean debugInternalChecks, boolean disableJustifications) {
 		super(atomStore, grounder);

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
@@ -90,7 +90,7 @@ public class DefaultSolver extends AbstractSolver implements SolverMaintainingSt
 				BranchingHeuristicFactory.getInstance(branchingHeuristic, grounder, assignment, choiceManager, random),
 				new NaiveHeuristic(choiceManager));
 		this.disableJustifications = disableJustifications;
-		this.performanceLog = new PerformanceLog(choiceManager, (TrailAssignment) assignment, 1000l);
+		this.performanceLog = new PerformanceLog(choiceManager, (TrailAssignment) assignment, 1000);
 	}
 
 	@Override

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/PerformanceLog.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/PerformanceLog.java
@@ -50,11 +50,9 @@ public class PerformanceLog {
 		this.msBetweenOutputs = msBetweenOutputs;
 	}
 
-	public void initializeIfNotInitialized() {
-		if (timeFirstEntry == null) {
-			timeFirstEntry = System.currentTimeMillis();
-			timeLastPerformanceLog = timeFirstEntry;
-		}
+	public void initialize() {
+		timeFirstEntry = System.currentTimeMillis();
+		timeLastPerformanceLog = timeFirstEntry;
 	}
 
 	/**

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/PerformanceLog.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/PerformanceLog.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2019 Siemens AG
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package at.ac.tuwien.kr.alpha.solver;
+
+import org.slf4j.Logger;
+
+/**
+ * Collects performance data (mainly number of decisions per second) and outputs them on demand.
+ */
+public class PerformanceLog {
+
+	private ChoiceManager choiceManager;
+	private TrailAssignment assignment;
+	private long msBetweenOutputs;
+	
+	private Long timeFirstEntry;
+	private Long timeLastPerformanceLog;
+	private int numberOfChoicesLastPerformanceLog;
+
+	/**
+	 * @param msBetweenOutputs
+	 */
+	public PerformanceLog(ChoiceManager choiceManager, TrailAssignment assignment, long msBetweenOutputs) {
+		super();
+		this.choiceManager = choiceManager;
+		this.assignment = assignment;
+		this.msBetweenOutputs = msBetweenOutputs;
+	}
+
+	public void initializeIfNotInitialized() {
+		if (timeFirstEntry == null) {
+			timeFirstEntry = System.currentTimeMillis();
+			timeLastPerformanceLog = timeFirstEntry;
+		}
+	}
+
+	/**
+	 * @param logger
+	 */
+	public void infoIfTimeForOutput(Logger logger) {
+		long currentTime = System.currentTimeMillis();
+		int currentNumberOfChoices = choiceManager.getChoices();
+		if (currentTime >= timeLastPerformanceLog + msBetweenOutputs) {
+			logger.info("Decisions in {}s: {}", (currentTime - timeLastPerformanceLog) / 1000.0f, currentNumberOfChoices - numberOfChoicesLastPerformanceLog);
+			timeLastPerformanceLog = currentTime;
+			numberOfChoicesLastPerformanceLog = currentNumberOfChoices;
+			float overallTime = (currentTime - timeFirstEntry) / 1000.0f;
+			float decisionsPerSec = currentNumberOfChoices / overallTime;
+			logger.info("Overall performance: {} decisions in {}s or {} decisions per sec. Overall replayed assignments: {}.", currentNumberOfChoices, overallTime, decisionsPerSec, assignment.replayCounter);
+		}
+	}
+}


### PR DESCRIPTION
Performance logs (e.g. "Overall performance: 6350 decisions in 27.02s or 235.0111 decisions per sec. Overall replayed assignments: 0") now continue counting when an answer set is found, i.e. they measure performance across the whole solving process.

Fixes #166