### PR TITLE
Fix log message in ChoiceManager.choose

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/ChoiceManager.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/ChoiceManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2018, the Alpha Team.
+ * Copyright (c) 2017-2019, the Alpha Team.
  * All rights reserved.
  *
  * Additional changes made by Siemens.
@@ -43,7 +43,7 @@ import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.TRUE;
 
 /**
  * This class provides functionality for choice point management, detection of active choice points, etc.
- * Copyright (c) 2017, the Alpha Team.
+ * Copyright (c) 2017-2019, the Alpha Team.
  */
 public class ChoiceManager implements Checkable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ChoiceManager.class);
@@ -186,7 +186,6 @@ public class ChoiceManager implements Checkable {
 	}
 
 	public void choose(Choice choice) {
-		LOGGER.debug("Choice {} is {}@{}", choices, choice, assignment.getDecisionLevel());
 		if (!choice.isBacktracked()) {
 			choices++;
 		}
@@ -194,6 +193,7 @@ public class ChoiceManager implements Checkable {
 		if (assignment.choose(choice.getAtom(), choice.getValue()) != null) {
 			throw oops("Picked choice is incompatible with current assignment");
 		}
+		LOGGER.debug("Choice {} is {}@{}", choices, choice, assignment.getDecisionLevel());
 
 		if (debugWatcher != null) {
 			debugWatcher.runWatcher();


### PR DESCRIPTION
Before this fix, the decision level was printed before it was increased, thus connecting the chosen atom with a wrong decision level in the log output.