### PR TITLE
Enable Gradle Build Scans

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,10 +7,10 @@ before_build:
   - ps: Get-Command java
 
 build_script:
-  - gradlew assemble --no-daemon
+  - gradlew build --scan --stacktrace
 
 test_script:
-  - gradlew check --no-daemon
+  - gradlew check
 
 after_test:
   - ps: |
@@ -19,7 +19,7 @@ after_test:
         Foreach-Object {
             $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $_))
         }
-  - gradlew bundledJar --no-daemon
+  - gradlew bundledJar
   - mv build/libs/alpha-bundled.jar alpha.jar
 
 artifacts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,12 @@ before_install:
   - export GRADLE_OPTS="-Xmx1g -Xss8m"
   - echo 'org.gradle.jvmargs=-Xmx1g' >> $HOME/.gradle/gradle.properties
 
+install:
+  - true
+
+script:
+  - ./gradlew build --scan --stacktrace
+
 after_success:
   - ./gradlew jacocoTestReport coveralls
   - bash <(curl -s https://codecov.io/bash)
@@ -54,10 +60,12 @@ notifications:
 # before_cache and after_cache to leverage caching
 # of dependencies according to Travis CI docs, see
 # https://docs.travis-ci.com/user/languages/java#Caching
+# Also according to Gradle docs, see
+# https://guides.gradle.org/executing-gradle-builds-on-travisci/#enable_caching_of_downloaded_artifacts
 before_cache:
   - rm -fv  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fvr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
-    - $HOME/.gradle/caches/$GRADLE_VERSION/
-    - $HOME/.gradle/caches/modules-2/
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
 	id 'jacoco'
 
 	id 'com.github.kt3k.coveralls' version '2.8.1'
+	id 'com.gradle.build-scan' version '2.2.1'
 }
 
 sourceCompatibility = 1.8
@@ -116,3 +117,16 @@ wrapper {
 	distributionType = 'ALL'
 }
 
+buildScan {
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+        termsOfServiceAgree = 'yes'
+	// Detect whether the build is running on Travis CI, and if
+	// so, add a reference from the build scan to the build.
+        if (System.getenv('TRAVIS')) {
+		tag 'ci'
+                link('Travis CI', System.getenv('TRAVIS_JOB_WEB_URL'))
+        }
+        buildScanPublished { com.gradle.scan.plugin.PublishedBuildScan scan ->
+                file('build/scan.txt') << "${scan.buildScanUri}\n"
+        }
+}


### PR DESCRIPTION
See https://scans.gradle.com/

With this addition we will have the possibility to access and share detailed information about the build process of Alpha, such as duration of build phases, an overview of dependencies, etc. To get an idea, check out a build scan from this PR's source branch: https://scans.gradle.com/s/j7kqgasr5a7am