### PR TITLE
fixed broken filter option (issue #189)

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/Main.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/Main.java
@@ -85,7 +85,7 @@ public class Main {
 	}
 
 	private static void computeAndConsumeAnswerSets(Alpha alpha, InputConfig inputCfg, Program program) {
-		Solver solver = alpha.prepareSolverFor(program);
+		Solver solver = alpha.prepareSolverFor(program, inputCfg.getFilter());
 		Stream<AnswerSet> stream = solver.stream();
 		if (alpha.getConfig().isSortAnswerSets()) {
 			stream = stream.sorted();

--- a/src/main/java/at/ac/tuwien/kr/alpha/config/CommandLineParser.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/config/CommandLineParser.java
@@ -27,19 +27,25 @@
  */
 package at.ac.tuwien.kr.alpha.config;
 
-import at.ac.tuwien.kr.alpha.common.Predicate;
-import at.ac.tuwien.kr.alpha.solver.BinaryNoGoodPropagationEstimation;
-import at.ac.tuwien.kr.alpha.solver.heuristics.BranchingHeuristicFactory.Heuristic;
-import org.apache.commons.cli.*;
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayOutputStream;
-import java.io.FileInputStream;
-import java.io.PrintWriter;
-import java.util.*;
-import java.util.function.Consumer;
+import at.ac.tuwien.kr.alpha.solver.BinaryNoGoodPropagationEstimation;
+import at.ac.tuwien.kr.alpha.solver.heuristics.BranchingHeuristicFactory.Heuristic;
 
 /**
  * Parses given argument lists (as passed when Alpha is called from command line) into {@link AlphaConfig}s and {@link InputConfig}s.
@@ -263,9 +269,8 @@ public class CommandLineParser {
 	}
 
 	private void handleFilters(Option opt, InputConfig cfg) {
-		Set<String> desiredPredicates = new HashSet<>(Arrays.asList(opt.getValues()));
-		java.util.function.Predicate<Predicate> filter = p -> desiredPredicates.contains(p.getName());
-		cfg.setFilter(filter);
+		String pred = opt.getValue().trim();
+		cfg.getDesiredPredicates().add(pred);
 	}
 
 	private void handleAspString(Option opt, InputConfig cfg) {

--- a/src/main/java/at/ac/tuwien/kr/alpha/config/InputConfig.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/config/InputConfig.java
@@ -2,8 +2,10 @@ package at.ac.tuwien.kr.alpha.config;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import at.ac.tuwien.kr.alpha.common.Predicate;
 import at.ac.tuwien.kr.alpha.common.fixedinterpretations.PredicateInterpretation;
@@ -18,7 +20,7 @@ public class InputConfig {
 	private List<String> files = new ArrayList<>();
 	private boolean literate = InputConfig.DEFAULT_LITERATE;
 	private int numAnswerSets = InputConfig.DEFAULT_NUM_ANSWER_SETS;
-	private java.util.function.Predicate<Predicate> filter = InputConfig.DEFAULT_FILTER;
+	private Set<String> desiredPredicates = new HashSet<>();
 	private Map<String, PredicateInterpretation> predicateMethods = new HashMap<>();
 
 	public static InputConfig forString(String str) {
@@ -52,11 +54,7 @@ public class InputConfig {
 	}
 
 	public java.util.function.Predicate<Predicate> getFilter() {
-		return this.filter;
-	}
-
-	public void setFilter(java.util.function.Predicate<Predicate> filter) {
-		this.filter = filter;
+		return this.desiredPredicates.isEmpty() ? InputConfig.DEFAULT_FILTER : p -> this.desiredPredicates.contains(p.getName());
 	}
 
 	public Map<String, PredicateInterpretation> getPredicateMethods() {
@@ -77,6 +75,14 @@ public class InputConfig {
 
 	public void setFiles(List<String> files) {
 		this.files = files;
+	}
+
+	public Set<String> getDesiredPredicates() {
+		return this.desiredPredicates;
+	}
+
+	public void setDesiredPredicates(Set<String> desiredPredicates) {
+		this.desiredPredicates = desiredPredicates;
 	}
 
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/GrounderFactory.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/GrounderFactory.java
@@ -30,6 +30,7 @@ package at.ac.tuwien.kr.alpha.grounder;
 import at.ac.tuwien.kr.alpha.common.AtomStore;
 import at.ac.tuwien.kr.alpha.common.Predicate;
 import at.ac.tuwien.kr.alpha.common.Program;
+import at.ac.tuwien.kr.alpha.config.InputConfig;
 import at.ac.tuwien.kr.alpha.grounder.bridges.Bridge;
 
 public final class GrounderFactory {
@@ -41,7 +42,11 @@ public final class GrounderFactory {
 		throw new IllegalArgumentException("Unknown grounder requested.");
 	}
 
+	public static Grounder getInstance(String name, Program program, AtomStore atomStore, java.util.function.Predicate<Predicate> filter, boolean debugInternalChecks) {
+		return getInstance(name, program, atomStore, filter, false, debugInternalChecks);
+	}	
+	
 	public static Grounder getInstance(String name, Program program, AtomStore atomStore, boolean debugInternalChecks) {
-		return getInstance(name, program, atomStore, p -> true, false, debugInternalChecks);
+		return getInstance(name, program, atomStore, InputConfig.DEFAULT_FILTER, false, debugInternalChecks);
 	}
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/AlphaTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/AlphaTest.java
@@ -60,8 +60,8 @@ import at.ac.tuwien.kr.alpha.common.atoms.ExternalLiteral;
 import at.ac.tuwien.kr.alpha.common.atoms.external.ExternalAtoms;
 import at.ac.tuwien.kr.alpha.common.fixedinterpretations.MethodPredicateInterpretation;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
-import at.ac.tuwien.kr.alpha.config.SystemConfig;
 import at.ac.tuwien.kr.alpha.config.InputConfig;
+import at.ac.tuwien.kr.alpha.config.SystemConfig;
 import at.ac.tuwien.kr.alpha.grounder.parser.InlineDirectives;
 
 public class AlphaTest {
@@ -373,14 +373,27 @@ public class AlphaTest {
 	}
 
 	/**
+	 * Verifies that filters are handled correctly (regression test case introduced when fixing issue #189)
+	 */
+	@Test
+	public void filterTest() {
+		String progstr = "a. b. c. d :- c. e(a, b) :- d.";
+		Alpha system = new Alpha();
+		Program prog = system.readProgramString(progstr, null);
+		Set<AnswerSet> actual = system.solve(prog, (p) -> p.equals(Predicate.getInstance("a", 0)) || p.equals(Predicate.getInstance("e", 2)))
+				.collect(Collectors.toSet());
+		Set<AnswerSet> expected = new HashSet<>(singletonList(new AnswerSetBuilder().predicate("a").predicate("e").symbolicInstance("a", "b").build()));
+		assertEquals(expected, actual);
+	}
+
+	/**
 	 * Runs a test that formerly caused some sort of exception.
 	 */
 	@Test
 	public void problematicRun_3col_1119654162577372() throws IOException {
 		/*
-		 * NOTE: This was constructed from the following commandline invocation:
-		 * -DebugEnableInternalChecks -q -g naive -s default -e 1119654162577372 -n 200
-		 * -i 3col-20-38.txt
+		 * NOTE: This was constructed from the following commandline invocation: -DebugEnableInternalChecks -q -g naive -s default -e 1119654162577372 -n 200 -i
+		 * 3col-20-38.txt
 		 */
 		problematicRun("3col-20-38.txt", 1119654162577372L, 200);
 	}
@@ -391,9 +404,8 @@ public class AlphaTest {
 	@Test
 	public void problematicRun_3col_1119718541727902() throws IOException {
 		/*
-		 * NOTE: This was constructed from the following commandline invocation:
-		 * -DebugEnableInternalChecks -q -g naive -s default -e 1119718541727902 -n 200
-		 * -i 3col-20-38.txt
+		 * NOTE: This was constructed from the following commandline invocation: -DebugEnableInternalChecks -q -g naive -s default -e 1119718541727902 -n 200 -i
+		 * 3col-20-38.txt
 		 */
 		problematicRun("3col-20-38.txt", 1119718541727902L, 200);
 	}
@@ -404,8 +416,7 @@ public class AlphaTest {
 	@Test
 	public void problematicRun_vehicle_97598271567626() throws IOException {
 		/*
-		 * NOTE: This was constructed from the following commandline invocation:
-		 * -DebugEnableInternalChecks -q -g naive -s default -e 97598271567626 -n 2 -i
+		 * NOTE: This was constructed from the following commandline invocation: -DebugEnableInternalChecks -q -g naive -s default -e 97598271567626 -n 2 -i
 		 * vehicle_normal_small.asp
 		 */
 		problematicRun("vehicle_normal_small.asp", 1119718541727902L, 2);
@@ -417,8 +428,7 @@ public class AlphaTest {
 	@Test
 	public void problematicRun_3col_1119718541727902_sorted_400() throws IOException {
 		/*
-		 * NOTE: This was constructed from the following commandline invocation:
-		 * -DebugEnableInternalChecks -q -g naive -s default -sort -n 400 -i
+		 * NOTE: This was constructed from the following commandline invocation: -DebugEnableInternalChecks -q -g naive -s default -sort -n 400 -i
 		 * 3col-20-38.txt
 		 */
 		SystemConfig cfg = new SystemConfig();

--- a/src/test/java/at/ac/tuwien/kr/alpha/MainTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/MainTest.java
@@ -70,6 +70,19 @@ public class MainTest {
 		System.setOut(sysOut);
 		assertTrue(newOut.toString().contains("{ b, p(a) }"));
 	}
+	
+	@Test
+	public void filterTest() {
+		PrintStream sysOut = System.out;
+		ByteArrayOutputStream newOut = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(newOut));
+		String[] args = Arrays.copyOf(argv, argv.length + 2);
+		args[args.length - 2] = "-f";
+		args[args.length - 1] = "b";
+		main(args);
+		System.setOut(sysOut);
+		assertTrue(newOut.toString().contains("{ b }"));
+	}
 
 // Made obsolete by refactoring - now covered by CommandLineParserTest#numAnswerSets
 //	@Test


### PR DESCRIPTION
- overloaded ```solve(..)``` and ```prepareSolverFor(..)``` in ```Alpha.java``` with optional filter parameter
- calling ```prepareSolverFor``` with filter got from ```InputConfig``` in ```Main```
- overloaded "simple version" of ```getInstance``` in ```GrounderFactory``` with optional filter parameter
- added test cases (in ```MainTest``` and ```AlphaTest```)