### PR TITLE
Add capability to count atoms for statistics

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/common/AtomStore.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/AtomStore.java
@@ -1,6 +1,34 @@
+/**
+ * Copyright (c) 2016-2019, the Alpha Team.
+ * All rights reserved.
+ *
+ * Additional changes made by Siemens.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package at.ac.tuwien.kr.alpha.common;
 
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
+import at.ac.tuwien.kr.alpha.solver.AtomCounter;
 
 import java.util.Iterator;
 
@@ -86,4 +114,6 @@ public interface AtomStore {
 
 		return sb.toString();
 	}
+
+	AtomCounter getAtomCounter();
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/AtomStoreImpl.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/AtomStoreImpl.java
@@ -30,6 +30,7 @@ package at.ac.tuwien.kr.alpha.common;
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
 import at.ac.tuwien.kr.alpha.grounder.IntIdGenerator;
 import at.ac.tuwien.kr.alpha.grounder.atoms.RuleAtom;
+import at.ac.tuwien.kr.alpha.solver.AtomCounter;
 
 import java.util.*;
 
@@ -37,14 +38,14 @@ import static at.ac.tuwien.kr.alpha.Util.oops;
 
 /**
  * This class stores ground atoms and provides the translation from an (integer) atomId to a (structured) predicate instance.
- * Copyright (c) 2016-2017, the Alpha Team.
  */
 public class AtomStoreImpl implements AtomStore {
-	private List<Atom> atomIdsToInternalBasicAtoms = new ArrayList<>();
-	private Map<Atom, Integer> predicateInstancesToAtomIds = new HashMap<>();
-	private IntIdGenerator atomIdGenerator = new IntIdGenerator(1);
+	private final List<Atom> atomIdsToInternalBasicAtoms = new ArrayList<>();
+	private final Map<Atom, Integer> predicateInstancesToAtomIds = new HashMap<>();
+	private final IntIdGenerator atomIdGenerator = new IntIdGenerator(1);
+	private final AtomCounter atomCounter = new AtomCounter();
 
-	private List<Integer> releasedAtomIds = new ArrayList<>();	// contains atomIds ready to be garbage collected if necessary.
+	private final List<Integer> releasedAtomIds = new ArrayList<>();	// contains atomIds ready to be garbage collected if necessary.
 
 	public AtomStoreImpl() {
 		// Create atomId for falsum (currently not needed, but it gets atomId 0, which cannot represent a negated literal).
@@ -63,6 +64,7 @@ public class AtomStoreImpl implements AtomStore {
 			id = atomIdGenerator.getNextId();
 			predicateInstancesToAtomIds.put(groundAtom, id);
 			atomIdsToInternalBasicAtoms.add(id, groundAtom);
+			atomCounter.add(groundAtom);
 		}
 
 		return id;
@@ -117,5 +119,10 @@ public class AtomStoreImpl implements AtomStore {
 	@Override
 	public int get(Atom atom) {
 		return predicateInstancesToAtomIds.get(atom);
+	}
+
+	@Override
+	public AtomCounter getAtomCounter() {
+		return atomCounter;
 	}
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/AtomCounter.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/AtomCounter.java
@@ -47,7 +47,7 @@ public class AtomCounter {
 	 * @return the number of atoms of the given type
 	 */
 	public int getNumberOfAtoms(Class<? extends Atom> type) {
-		return countByType.get(type);
+		return countByType.getOrDefault(type, 0);
 	}
 
 	/**

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/AtomCounter.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/AtomCounter.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2019 Siemens AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package at.ac.tuwien.kr.alpha.solver;
+
+import at.ac.tuwien.kr.alpha.common.atoms.Atom;
+
+import java.util.*;
+
+/**
+ * Counts the number of ground atoms stored for each type (i.e., subclass of {@link Atom}.
+ * For every atom, only the counter for one class (the most specific one) is incremented,
+ * not the counters for more general classes of which the atom is also an instance.
+ */
+public class AtomCounter {
+
+	private final Map<Class<? extends Atom>, Integer> countByType = new HashMap<>();
+
+	public void add(Atom atom) {
+		countByType.compute(atom.getClass(), (k, v) -> (v == null) ? 1 : v + 1);
+	}
+
+	/**
+	 * @param type the class of atoms to count
+	 * @return the number of atoms of the given type
+	 */
+	public int getNumberOfAtoms(Class<? extends Atom> type) {
+		return countByType.get(type);
+	}
+
+	/**
+	 * @return a string giving statistics on numbers of atoms by type
+	 */
+	public String getStatsByType() {
+		List<String> statsList = new ArrayList<>();
+		for (Map.Entry<Class<? extends Atom>, Integer> entry : countByType.entrySet()) {
+			statsList.add(entry.getKey().getSimpleName() + ": " + entry.getValue());
+		}
+		Collections.sort(statsList);
+		return String.join(" ", statsList);
+	}
+
+}

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
@@ -27,23 +27,47 @@
  */
 package at.ac.tuwien.kr.alpha.solver;
 
-import at.ac.tuwien.kr.alpha.common.*;
-import at.ac.tuwien.kr.alpha.common.atoms.*;
+import at.ac.tuwien.kr.alpha.common.AnswerSet;
+import at.ac.tuwien.kr.alpha.common.Assignment;
+import at.ac.tuwien.kr.alpha.common.AtomStore;
+import at.ac.tuwien.kr.alpha.common.NoGood;
+import at.ac.tuwien.kr.alpha.common.Rule;
+import at.ac.tuwien.kr.alpha.common.atoms.Atom;
+import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
+import at.ac.tuwien.kr.alpha.common.atoms.ComparisonAtom;
+import at.ac.tuwien.kr.alpha.common.atoms.Literal;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.config.SystemConfig;
-import at.ac.tuwien.kr.alpha.grounder.*;
+import at.ac.tuwien.kr.alpha.grounder.Grounder;
+import at.ac.tuwien.kr.alpha.grounder.NonGroundRule;
+import at.ac.tuwien.kr.alpha.grounder.ProgramAnalyzingGrounder;
+import at.ac.tuwien.kr.alpha.grounder.Substitution;
 import at.ac.tuwien.kr.alpha.grounder.atoms.RuleAtom;
-import at.ac.tuwien.kr.alpha.solver.heuristics.*;
+import at.ac.tuwien.kr.alpha.solver.heuristics.BranchingHeuristic;
+import at.ac.tuwien.kr.alpha.solver.heuristics.BranchingHeuristicFactory;
+import at.ac.tuwien.kr.alpha.solver.heuristics.ChainedBranchingHeuristics;
+import at.ac.tuwien.kr.alpha.solver.heuristics.HeuristicsConfiguration;
+import at.ac.tuwien.kr.alpha.solver.heuristics.NaiveHeuristic;
 import at.ac.tuwien.kr.alpha.solver.learning.GroundConflictNoGoodLearner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Random;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import static at.ac.tuwien.kr.alpha.Util.oops;
-import static at.ac.tuwien.kr.alpha.common.Literals.*;
+import static at.ac.tuwien.kr.alpha.common.Literals.atomOf;
+import static at.ac.tuwien.kr.alpha.common.Literals.atomToLiteral;
+import static at.ac.tuwien.kr.alpha.common.Literals.atomToNegatedLiteral;
 import static at.ac.tuwien.kr.alpha.solver.NoGoodStore.LBD_NO_VALUE;
 import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.MBT;
 import static at.ac.tuwien.kr.alpha.solver.heuristics.BranchingHeuristic.DEFAULT_CHOICE_LITERAL;

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
@@ -28,16 +28,10 @@
 package at.ac.tuwien.kr.alpha.solver;
 
 import at.ac.tuwien.kr.alpha.common.*;
-import at.ac.tuwien.kr.alpha.common.atoms.Atom;
-import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
-import at.ac.tuwien.kr.alpha.common.atoms.ComparisonAtom;
-import at.ac.tuwien.kr.alpha.common.atoms.Literal;
+import at.ac.tuwien.kr.alpha.common.atoms.*;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.config.SystemConfig;
-import at.ac.tuwien.kr.alpha.grounder.Grounder;
-import at.ac.tuwien.kr.alpha.grounder.NonGroundRule;
-import at.ac.tuwien.kr.alpha.grounder.ProgramAnalyzingGrounder;
-import at.ac.tuwien.kr.alpha.grounder.Substitution;
+import at.ac.tuwien.kr.alpha.grounder.*;
 import at.ac.tuwien.kr.alpha.grounder.atoms.RuleAtom;
 import at.ac.tuwien.kr.alpha.solver.heuristics.*;
 import at.ac.tuwien.kr.alpha.solver.learning.GroundConflictNoGoodLearner;
@@ -563,6 +557,8 @@ public class DefaultSolver extends AbstractSolver implements SolverMaintainingSt
 					LOGGER.debug(heuristicToDecisionCounter.getKey() + ": " + heuristicToDecisionCounter.getValue());
 				}
 			}
+			AtomCounter atomCounter = atomStore.getAtomCounter();
+			LOGGER.debug("Number of atoms by type: " + atomCounter.getStatsByType());
 		}
 	}
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/AtomCounterTests.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/AtomCounterTests.java
@@ -131,21 +131,4 @@ public class AtomCounterTests {
 		assertTrue("Expected number of " + classOfAtoms.getSimpleName() + "s not contained in stats string", atomCounter.getStatsByType().contains(classOfAtoms.getSimpleName() + ": " + expectedNumber));
 	}
 
-	@at.ac.tuwien.kr.alpha.common.atoms.external.Predicate
-	public static boolean thinger(Thingy thingy) {
-		return true;
-	}
-
-	private static class Thingy implements Comparable<Thingy> {
-		@Override
-		public String toString() {
-			return "thingy";
-		}
-
-		@Override
-		public int compareTo(Thingy o) {
-			return 0;
-		}
-	}
-
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/AtomCounterTests.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/AtomCounterTests.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2019 Siemens AG
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package at.ac.tuwien.kr.alpha.solver;
+
+import at.ac.tuwien.kr.alpha.common.*;
+import at.ac.tuwien.kr.alpha.common.atoms.AggregateAtom;
+import at.ac.tuwien.kr.alpha.common.atoms.Atom;
+import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
+import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
+import at.ac.tuwien.kr.alpha.common.terms.Term;
+import at.ac.tuwien.kr.alpha.grounder.NonGroundRule;
+import at.ac.tuwien.kr.alpha.grounder.Substitution;
+import at.ac.tuwien.kr.alpha.grounder.atoms.ChoiceAtom;
+import at.ac.tuwien.kr.alpha.grounder.atoms.RuleAtom;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AtomCounterTests {
+
+	private final AtomStore atomStore = new AtomStoreImpl();
+
+	@Test
+	public void testGetNumberOfAtoms() throws NoSuchMethodException {
+		final AtomCounter atomCounter = atomStore.getAtomCounter();
+
+		expectGetNumberOfAtoms(atomCounter, BasicAtom.class, 0);
+		expectGetNumberOfAtoms(atomCounter, AggregateAtom.class, 0);
+		expectGetNumberOfAtoms(atomCounter, ChoiceAtom.class, 0);
+		expectGetNumberOfAtoms(atomCounter, RuleAtom.class, 0);
+
+		createBasicAtom1();
+		createBasicAtom2();
+		createAggregateAtom();
+		createChoiceAtom();
+		createRuleAtom();
+
+		expectGetNumberOfAtoms(atomCounter, BasicAtom.class, 2);
+		expectGetNumberOfAtoms(atomCounter, AggregateAtom.class, 1);
+		expectGetNumberOfAtoms(atomCounter, ChoiceAtom.class, 1);
+		expectGetNumberOfAtoms(atomCounter, RuleAtom.class, 1);
+	}
+
+	@Test
+	public void testGetStatsByType() throws NoSuchMethodException {
+		final AtomCounter atomCounter = atomStore.getAtomCounter();
+
+		createBasicAtom1();
+		createBasicAtom2();
+		createAggregateAtom();
+		createChoiceAtom();
+		createRuleAtom();
+
+		expectGetStatsByType(atomCounter, BasicAtom.class, 2);
+		expectGetStatsByType(atomCounter, AggregateAtom.class, 1);
+		expectGetStatsByType(atomCounter, ChoiceAtom.class, 1);
+		expectGetStatsByType(atomCounter, RuleAtom.class, 1);
+	}
+
+	private void createBasicAtom1() {
+		atomStore.putIfAbsent(new BasicAtom(Predicate.getInstance("p", 0)));
+	}
+
+	private void createBasicAtom2() {
+		atomStore.putIfAbsent(new BasicAtom(Predicate.getInstance("q", 1), ConstantTerm.getInstance(1)));
+	}
+
+	private void createAggregateAtom() {
+		final ConstantTerm<Integer> c1 = ConstantTerm.getInstance(1);
+		final ConstantTerm<Integer> c2 = ConstantTerm.getInstance(2);
+		final ConstantTerm<Integer> c3 = ConstantTerm.getInstance(3);
+		List<Term> basicTerms = Arrays.asList(c1, c2, c3);
+		AggregateAtom.AggregateElement aggregateElement = new AggregateAtom.AggregateElement(basicTerms, Collections.singletonList(new BasicAtom(Predicate.getInstance("p", 3), c1, c2, c3).toLiteral()));
+		atomStore.putIfAbsent(new AggregateAtom(ComparisonOperator.LE, c1, null, null, AggregateAtom.AGGREGATEFUNCTION.COUNT, Collections.singletonList(aggregateElement)));
+	}
+
+	private void createChoiceAtom() {
+		atomStore.putIfAbsent(ChoiceAtom.on(1));
+	}
+
+	private void createRuleAtom() {
+		Atom atomAA = new BasicAtom(Predicate.getInstance("aa", 0));
+		Rule ruleAA = new Rule(new DisjunctiveHead(Collections.singletonList(atomAA)), Collections.singletonList(new BasicAtom(Predicate.getInstance("bb", 0)).toLiteral(false)));
+		atomStore.putIfAbsent(new RuleAtom(NonGroundRule.constructNonGroundRule(ruleAA), new Substitution()));
+	}
+
+	private void expectGetNumberOfAtoms(AtomCounter atomCounter, Class<? extends Atom> classOfAtoms, int expectedNumber) {
+		assertEquals("Unexpected number of " + classOfAtoms.getSimpleName() + "s", expectedNumber, atomCounter.getNumberOfAtoms(classOfAtoms));
+	}
+
+	private void expectGetStatsByType(AtomCounter atomCounter, Class<? extends Atom> classOfAtoms, int expectedNumber) {
+		assertTrue("Expected number of " + classOfAtoms.getSimpleName() + "s not contained in stats string", atomCounter.getStatsByType().contains(classOfAtoms.getSimpleName() + ": " + expectedNumber));
+	}
+
+	@at.ac.tuwien.kr.alpha.common.atoms.external.Predicate
+	public static boolean thinger(Thingy thingy) {
+		return true;
+	}
+
+	private static class Thingy implements Comparable<Thingy> {
+		@Override
+		public String toString() {
+			return "thingy";
+		}
+
+		@Override
+		public int compareTo(Thingy o) {
+			return 0;
+		}
+	}
+
+}

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/AtomCounterTests.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/AtomCounterTests.java
@@ -25,7 +25,12 @@
  */
 package at.ac.tuwien.kr.alpha.solver;
 
-import at.ac.tuwien.kr.alpha.common.*;
+import at.ac.tuwien.kr.alpha.common.AtomStore;
+import at.ac.tuwien.kr.alpha.common.AtomStoreImpl;
+import at.ac.tuwien.kr.alpha.common.ComparisonOperator;
+import at.ac.tuwien.kr.alpha.common.DisjunctiveHead;
+import at.ac.tuwien.kr.alpha.common.Predicate;
+import at.ac.tuwien.kr.alpha.common.Rule;
 import at.ac.tuwien.kr.alpha.common.atoms.AggregateAtom;
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
@@ -35,6 +40,7 @@ import at.ac.tuwien.kr.alpha.grounder.NonGroundRule;
 import at.ac.tuwien.kr.alpha.grounder.Substitution;
 import at.ac.tuwien.kr.alpha.grounder.atoms.ChoiceAtom;
 import at.ac.tuwien.kr.alpha.grounder.atoms.RuleAtom;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -46,7 +52,12 @@ import static org.junit.Assert.assertTrue;
 
 public class AtomCounterTests {
 
-	private final AtomStore atomStore = new AtomStoreImpl();
+	private AtomStore atomStore;
+
+	@Before
+	public void setUp() {
+		this.atomStore = new AtomStoreImpl();
+	}
 
 	@Test
 	public void testGetNumberOfAtoms() throws NoSuchMethodException {


### PR DESCRIPTION
Adds the capability to count atoms (grouped by classes implementing `Atom`). The numbers are currently printed only in debug log messages, similarly as numbers of nogoods in 84d86b3437841cc2007bd09863e3aaa4bc3d8dac. In the future, all this information shall be included in the statistics (cf. #113).