### PR TITLE
Fix deprecation warnings for gradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,11 @@ repositories {
 /* The following configuration directive is a work-around for a fault in the Gradle
  * ANTLR plugin. It would require both antlr4 and antlr4-runtime at compile time and
  * at run time, which unnecessarily bloats our JARs. Only antlr4-runtime is needed.
- * We therefore remove this extension of antlr dependenIterablecies being compile dependencies
+ * We therefore remove this extension of antlr dependencies being compile dependencies
  * and reintroduce them on our own.
  */
 configurations {
-	compile {
+	implementation {
 		extendsFrom = extendsFrom.findAll { it != configurations.antlr }
 	}
 }
@@ -37,15 +37,15 @@ dependencies {
 	antlr group: 'org.antlr', name: 'antlr4', version: "${antlrVersion}"
 
 	// Re-introduce antlr4-runtime as compile dependency.
-	compile group: 'org.antlr', name: 'antlr4-runtime', version: "${antlrVersion}"
+	implementation group: 'org.antlr', name: 'antlr4-runtime', version: "${antlrVersion}"
 
-	compile group: 'ch.qos.logback',     name: 'logback-classic',      version: '1.1.7'
-	compile group: 'commons-cli',        name: 'commons-cli',          version: '1.3.1'
-	compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.1'
-	compile group: 'org.apache.commons', name: 'commons-lang3',        version: '3.6'
-	compile group: 'org.reflections',    name: 'reflections',          version: '0.9.11'
+	implementation group: 'ch.qos.logback',     name: 'logback-classic',      version: '1.1.7'
+	implementation group: 'commons-cli',        name: 'commons-cli',          version: '1.3.1'
+	implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.1'
+	implementation group: 'org.apache.commons', name: 'commons-lang3',        version: '3.6'
+	implementation group: 'org.reflections',    name: 'reflections',          version: '0.9.11'
 
-	testCompile group: 'junit', name: 'junit', version: '4.12'
+	testImplementation group: 'junit', name: 'junit', version: '4.12'
 }
 
 tasks.withType(AntlrTask) {
@@ -81,10 +81,13 @@ task bundledJar(type: Jar) {
 	}
 
 	from {
-		configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+		configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) }
 	}
 
-	archiveName = "${project.name}-bundled.jar"
+	archiveFileName = "${project.name}-bundled.jar"
+
+	exclude('META-INF/LICENSE.txt')
+	exclude('META-INF/NOTICE.txt')
 
 	with jar
 }

--- a/build.gradle
+++ b/build.gradle
@@ -86,8 +86,15 @@ task bundledJar(type: Jar) {
 
 	archiveFileName = "${project.name}-bundled.jar"
 
-	exclude('META-INF/LICENSE.txt')
-	exclude('META-INF/NOTICE.txt')
+	/*
+	 * In order to make sure wo don't overwrite NOTICE and LICENSE files coming from dependency
+	 * jars with each other, number them while copying
+	 */
+	int i = 1
+	rename { name -> name.equals("NOTICE.txt") ? "NOTICE." + (i++) + ".txt" :  null }
+
+	int j = 1
+	rename { name -> name.equals("LICENSE.txt") ? "LICENSE." + (j++) + ".txt" : null }
 
 	with jar
 }


### PR DESCRIPTION
Addresses issue #214 

* changed deprecated dependency config "compile" to "implementation"
* changed deprecated property "archiveName" to use "archiveFileName" for bundledJar task
* exclude all "LICENSE.txt" and "NOTICE.txt" files from bundled jar

Note that LICENSE and NOTICE files are excluded from bundled jar in order to avoid having to handle duplicate files since all apache commons dependencies have their own files of that name which would have to be properly handled (ideally merged) otherwise. The aforementioned "proper handling" would require use of the gradle shadow plugin, which unfortunately is not gradle 7 compliant itself (as of version 5.2.0)