### PR TITLE
separate logback configs for tests and bundled jar

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -5,19 +5,8 @@
             <pattern>%5relative %.-1level %20.20logger %msg %n</pattern>
         </encoder>
     </appender>
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>junit.log</file>
-        <append>false</append>
-        <encoder>
-            <!-- Reference at http://logback.qos.ch/manual/layouts.html#conversionWord -->
-            <pattern>%-4r %-5level %logger{35}: %msg%n</pattern>
-        </encoder>
-    </appender>
+    
     <root level="INFO">
-        <appender-ref ref="FILE" />
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="junit" level="INFO">
-        <appender-ref ref="STDOUT" />
-    </logger>
 </configuration>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,23 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- Reference at http://logback.qos.ch/manual/layouts.html#conversionWord -->
+            <pattern>%5relative %.-1level %20.20logger %msg %n</pattern>
+        </encoder>
+    </appender>
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>junit.log</file>
+        <append>false</append>
+        <encoder>
+            <!-- Reference at http://logback.qos.ch/manual/layouts.html#conversionWord -->
+            <pattern>%-4r %-5level %logger{35}: %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="DEBUG">
+        <appender-ref ref="FILE" />
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="junit" level="INFO">
+        <appender-ref ref="STDOUT" />
+    </logger>
+</configuration>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -13,11 +13,12 @@
             <pattern>%-4r %-5level %logger{35}: %msg%n</pattern>
         </encoder>
     </appender>
+    
+    <logger name="at.ac.tuwien.kr.alpha.grounder.NaiveGrounder" level="INFO"/>
+    <logger name="at.ac.tuwien.kr.alpha.solver" level="INFO"/>
+    
     <root level="DEBUG">
         <appender-ref ref="FILE" />
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="junit" level="INFO">
-        <appender-ref ref="STDOUT" />
-    </logger>
 </configuration>


### PR DESCRIPTION
Use separate logback.xmls for testing and jar file:
* src/main/resources/logback.xml: Used in jar file (both bundledJar and normal "slim" jar), only logging to stdout, level = INFO
* src/test/resources/logback.xml: Used for unit tests, logging to stdout and junit.log, level = DEBUG

Addresses issue #204 