### PR TITLE
Feature: Render answer sets as excel workbooks (xlsx files)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,16 +87,16 @@ task bundledJar(type: Jar) {
 	}
 
 	archiveFileName = "${project.name}-bundled.jar"
-
+	
 	/*
-	 * In order to make sure wo don't overwrite NOTICE and LICENSE files coming from dependency
+	 * In order to make sure we don't overwrite NOTICE and LICENSE files coming from dependency
 	 * jars with each other, number them while copying
 	 */
 	int i = 1
-	rename { name -> name.equals("NOTICE.txt") ? "NOTICE." + (i++) + ".txt" :  null }
+	rename { name -> (name.equals("NOTICE.txt") || name.equals("NOTICE")) ? "NOTICE." + (i++) + ".txt" :  null }
 
 	int j = 1
-	rename { name -> name.equals("LICENSE.txt") ? "LICENSE." + (j++) + ".txt" : null }
+	rename { name -> (name.equals("LICENSE.txt") || name.equals("LICENSE")) ? "LICENSE." + (j++) + ".txt" : null }
 
 	with jar
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
 	implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.1'
 	implementation group: 'org.apache.commons', name: 'commons-lang3',        version: '3.6'
 	implementation group: 'org.reflections',    name: 'reflections',          version: '0.9.11'
+	implementation group: 'org.apache.poi',     name: 'poi',                  version: '4.1.1'
+	implementation group: 'org.apache.poi',     name: 'poi-ooxml',            version: '4.1.1'
 
 	testImplementation group: 'junit', name: 'junit', version: '4.12'
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/AnswerSetToXlsxWriter.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/AnswerSetToXlsxWriter.java
@@ -8,7 +8,11 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.function.BiConsumer;
 
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import at.ac.tuwien.kr.alpha.api.mapper.AnswerSetToObjectMapper;
 import at.ac.tuwien.kr.alpha.api.mapper.impl.AnswerSetToWorkbookMapper;
@@ -37,6 +41,20 @@ public class AnswerSetToXlsxWriter implements BiConsumer<Integer, AnswerSet> {
 		} catch (IOException ex) {
 			System.err.println("Failed writing answer set as xlsx file! (" + ex.getMessage() + ")");
 		}
+	}
+
+	public static void writeUnsatInfo(Path path) throws IOException {
+		Workbook workbook = new XSSFWorkbook();
+		// first, create a worksheet for 0-arity predicates
+		Sheet sheet = workbook.createSheet("Unsatisfiable");
+		Row row = sheet.createRow(0);
+		Cell cell = row.createCell(0);
+		cell.setCellValue("Input is unsatisfiable - No answer sets!");
+		sheet.autoSizeColumn(0);
+		OutputStream os = Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+		workbook.write(os);
+		workbook.close();
+		os.close();
 	}
 
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/AnswerSetToXlsxWriter.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/AnswerSetToXlsxWriter.java
@@ -1,0 +1,42 @@
+package at.ac.tuwien.kr.alpha;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.function.BiConsumer;
+
+import org.apache.poi.ss.usermodel.Workbook;
+
+import at.ac.tuwien.kr.alpha.api.mapper.AnswerSetToObjectMapper;
+import at.ac.tuwien.kr.alpha.api.mapper.impl.AnswerSetToWorkbookMapper;
+import at.ac.tuwien.kr.alpha.common.AnswerSet;
+
+public class AnswerSetToXlsxWriter implements BiConsumer<Integer, AnswerSet> {
+
+	private String targetBasePath;
+	private AnswerSetToObjectMapper<Workbook> answerSetMapper;
+
+	public AnswerSetToXlsxWriter(String targetBasePath) {
+		this.targetBasePath = targetBasePath;
+		this.answerSetMapper = new AnswerSetToWorkbookMapper();
+	}
+
+	@Override
+	public void accept(Integer num, AnswerSet as) {
+		try {
+			Path outputPath = Paths.get(this.targetBasePath + "." + num + ".xlsx");
+			OutputStream os = Files.newOutputStream(outputPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+			Workbook wb = this.answerSetMapper.mapFromAnswerSet(as);
+			wb.write(os);
+			wb.close();
+			os.close();
+			System.out.println("Answer set written to file " + outputPath.toString());
+		} catch (IOException ex) {
+			System.err.println("Failed writing answer set as xlsx file! (" + ex.getMessage() + ")");
+		}
+	}
+
+}

--- a/src/main/java/at/ac/tuwien/kr/alpha/Main.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/Main.java
@@ -38,6 +38,7 @@ import org.apache.commons.cli.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import at.ac.tuwien.kr.alpha.api.Alpha;
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
 import at.ac.tuwien.kr.alpha.common.Program;
 import at.ac.tuwien.kr.alpha.config.AlphaConfig;

--- a/src/main/java/at/ac/tuwien/kr/alpha/Main.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/Main.java
@@ -29,7 +29,6 @@ package at.ac.tuwien.kr.alpha;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
@@ -120,7 +119,7 @@ public class Main {
 				System.out.println("UNSATISFIABLE");
 				if (inputCfg.isWriteAnswerSetsAsXlsx()) {
 					try {
-						Files.createFile(Paths.get(inputCfg.getAnswerSetFileOutputPath() + ".UNSAT.xlsx"));
+						AnswerSetToXlsxWriter.writeUnsatInfo(Paths.get(inputCfg.getAnswerSetFileOutputPath() + ".UNSAT.xlsx"));
 					} catch (IOException ex) {
 						System.err.println("Failed writing unsat file!");
 					}

--- a/src/main/java/at/ac/tuwien/kr/alpha/Main.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/Main.java
@@ -29,16 +29,23 @@ package at.ac.tuwien.kr.alpha;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.antlr.v4.runtime.RecognitionException;
 import org.apache.commons.cli.ParseException;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import at.ac.tuwien.kr.alpha.api.Alpha;
+import at.ac.tuwien.kr.alpha.api.mapper.impl.AnswerSetToWorkbookMapper;
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
 import at.ac.tuwien.kr.alpha.common.Program;
 import at.ac.tuwien.kr.alpha.config.AlphaConfig;
@@ -99,7 +106,25 @@ public class Main {
 
 		if (!alpha.getConfig().isQuiet()) {
 			AtomicInteger counter = new AtomicInteger(0);
-			stream.forEach(as -> System.out.println("Answer set " + counter.incrementAndGet() + ":" + System.lineSeparator() + as.toString()));
+			// stream.forEach(as -> System.out.println("Answer set " + counter.incrementAndGet() + ":" + System.lineSeparator() + as.toString()));
+			stream.forEach(as -> {
+				int cnt = counter.incrementAndGet();
+				System.out.println("Answer set " + Integer.toString(cnt) + ":" + System.lineSeparator() + as.toString());
+				if (inputCfg.isWriteAnswerSetsAsXlsx()) {
+					try {
+						Path outputPath = Paths.get(inputCfg.getAnswerSetFileOutputPath() + "." + Integer.toString(cnt) + ".xlsx");
+						OutputStream os = Files.newOutputStream(outputPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE,
+								StandardOpenOption.TRUNCATE_EXISTING);
+						Workbook wb = new AnswerSetToWorkbookMapper().mapFromAnswerSet(as);
+						wb.write(os);
+						wb.close();
+						os.close();
+						System.out.println("Answer set written to file " + outputPath.toString());
+					} catch (IOException ex) {
+						System.err.println("Failed writing answer set as xlsx file! (" + ex.getMessage() + ")");
+					}
+				}
+			});
 			if (counter.get() == 0) {
 				System.out.println("UNSATISFIABLE");
 			} else {

--- a/src/main/java/at/ac/tuwien/kr/alpha/api/Alpha.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/api/Alpha.java
@@ -25,8 +25,9 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package at.ac.tuwien.kr.alpha;
+package at.ac.tuwien.kr.alpha.api;
 
+import at.ac.tuwien.kr.alpha.Util;
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
 import at.ac.tuwien.kr.alpha.common.AtomStore;
 import at.ac.tuwien.kr.alpha.common.AtomStoreImpl;

--- a/src/main/java/at/ac/tuwien/kr/alpha/api/mapper/AnswerSetToObjectMapper.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/api/mapper/AnswerSetToObjectMapper.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2020, the Alpha Team.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package at.ac.tuwien.kr.alpha.api.mapper;
+
+import at.ac.tuwien.kr.alpha.common.AnswerSet;
+
+/**
+ * Copyright (c) 2020, the Alpha Team.
+ * 
+ * Interface definition for an adapter that maps from an {@link AnswerSet} to an instance of the implementation's generic type T.
+ * 
+ * @param <T> the type to which to map answer sets
+ */
+public interface AnswerSetToObjectMapper<T> {
+
+	T mapFromAnswerSet(AnswerSet answerSet);
+
+}

--- a/src/main/java/at/ac/tuwien/kr/alpha/api/mapper/impl/AnswerSetToWorkbookMapper.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/api/mapper/impl/AnswerSetToWorkbookMapper.java
@@ -25,12 +25,22 @@
  */
 package at.ac.tuwien.kr.alpha.api.mapper.impl;
 
+import java.util.List;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import at.ac.tuwien.kr.alpha.api.mapper.AnswerSetToObjectMapper;
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
+import at.ac.tuwien.kr.alpha.common.Predicate;
+import at.ac.tuwien.kr.alpha.common.atoms.Atom;
+import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
+import at.ac.tuwien.kr.alpha.common.terms.Term;
 
 /**
  * Implementation of {@link AnswerSetToObjectMapper} that generates an office open xml workbook ("excel file") from a given answer set.
@@ -41,10 +51,55 @@ public class AnswerSetToWorkbookMapper implements AnswerSetToObjectMapper<Workbo
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(AnswerSetToWorkbookMapper.class);
 
+	/**
+	 * Creates an xlsx workbook containing all the atoms from the given {@link AnswerSet} with one sheet per predicate. All predicates with arity 0 are listed
+	 * in a special sheet called "flags". Caution, potential resource leak: note that the returned workbook needs to be closed by the caller once it has been
+	 * processed (written to file etc).
+	 */
 	@Override
 	public Workbook mapFromAnswerSet(AnswerSet answerSet) {
-		// TODO Auto-generated method stub
-		return null;
+		LOGGER.debug("Start mapping answer set to workbook");
+		Workbook workbook = new XSSFWorkbook();
+		// first, create a worksheet for 0-arity predicates
+		Sheet flags = workbook.createSheet("Flags");
+		Sheet currentPredicateSheet;
+		for (Predicate pred : answerSet.getPredicates()) {
+			if (pred.getArity() == 0) {
+				// 0-artiy predicate has no instances in answer set, create a dummy atom
+				this.writeAtomToSheet(flags, new BasicAtom(pred));
+			} else {
+				currentPredicateSheet = workbook.createSheet(pred.getName() + "_" + pred.getArity());
+				for (Atom atom : answerSet.getPredicateInstances(pred)) {
+					this.writeAtomToSheet(currentPredicateSheet, atom);
+				}
+			}
+		}
+		return workbook;
+	}
+
+	private void writeAtomToSheet(Sheet sheet, Atom atom) {
+		int rownum = -1;
+		if (sheet.getLastRowNum() == 0 && sheet.getRow(0) == null) {
+			// sheet is empty, start at row zero
+			rownum = 0;
+		} else {
+			rownum = sheet.getLastRowNum() + 1;
+		}
+		Row atomRow = sheet.createRow(rownum);
+		List<Term> terms = atom.getTerms();
+		Cell currCell;
+		if (terms.isEmpty()) {
+			// 0-arity atom
+			currCell = atomRow.createCell(0);
+			currCell.setCellValue(atom.getPredicate().getName());
+			sheet.autoSizeColumn(0);
+		} else {
+			for (int i = 0; i < terms.size(); i++) {
+				currCell = atomRow.createCell(i);
+				currCell.setCellValue(terms.get(i).toString());
+				sheet.autoSizeColumn(i);
+			}
+		}
 	}
 
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/api/mapper/impl/AnswerSetToWorkbookMapper.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/api/mapper/impl/AnswerSetToWorkbookMapper.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2020, the Alpha Team.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package at.ac.tuwien.kr.alpha.api.mapper.impl;
+
+import org.apache.poi.ss.usermodel.Workbook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import at.ac.tuwien.kr.alpha.api.mapper.AnswerSetToObjectMapper;
+import at.ac.tuwien.kr.alpha.common.AnswerSet;
+
+/**
+ * Implementation of {@link AnswerSetToObjectMapper} that generates an office open xml workbook ("excel file") from a given answer set.
+ * 
+ * Copyright (c) 2019, the Alpha Team.
+ */
+public class AnswerSetToWorkbookMapper implements AnswerSetToObjectMapper<Workbook> {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(AnswerSetToWorkbookMapper.class);
+
+	@Override
+	public Workbook mapFromAnswerSet(AnswerSet answerSet) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/src/main/java/at/ac/tuwien/kr/alpha/api/mapper/impl/AnswerSetToWorkbookMapper.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/api/mapper/impl/AnswerSetToWorkbookMapper.java
@@ -45,7 +45,7 @@ import at.ac.tuwien.kr.alpha.common.terms.Term;
 /**
  * Implementation of {@link AnswerSetToObjectMapper} that generates an office open xml workbook ("excel file") from a given answer set.
  * 
- * Copyright (c) 2019, the Alpha Team.
+ * Copyright (c) 2020, the Alpha Team.
  */
 public class AnswerSetToWorkbookMapper implements AnswerSetToObjectMapper<Workbook> {
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/api/mapper/impl/AnswerSetToWorkbookMapper.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/api/mapper/impl/AnswerSetToWorkbookMapper.java
@@ -43,7 +43,6 @@ import at.ac.tuwien.kr.alpha.api.mapper.AnswerSetToObjectMapper;
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
 import at.ac.tuwien.kr.alpha.common.Predicate;
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
-import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
 import at.ac.tuwien.kr.alpha.common.terms.Term;
 
 /**
@@ -74,7 +73,7 @@ public class AnswerSetToWorkbookMapper implements AnswerSetToObjectMapper<Workbo
 		for (Predicate pred : answerSet.getPredicates()) {
 			if (pred.getArity() == 0) {
 				// 0-artiy predicate has no instances in answer set, create a dummy atom
-				this.writeAtomToSheet(flags, new BasicAtom(pred));
+				this.writeAtomToSheet(flags, answerSet.getPredicateInstances(pred).first());
 			} else {
 				headerContent = new String[pred.getArity()];
 				for (int i = 0; i < headerContent.length; i++) {

--- a/src/main/java/at/ac/tuwien/kr/alpha/api/mapper/impl/AnswerSetToWorkbookMapper.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/api/mapper/impl/AnswerSetToWorkbookMapper.java
@@ -72,7 +72,6 @@ public class AnswerSetToWorkbookMapper implements AnswerSetToObjectMapper<Workbo
 		String[] headerContent;
 		for (Predicate pred : answerSet.getPredicates()) {
 			if (pred.getArity() == 0) {
-				// 0-artiy predicate has no instances in answer set, create a dummy atom
 				this.writeAtomToSheet(flags, answerSet.getPredicateInstances(pred).first());
 			} else {
 				headerContent = new String[pred.getArity()];

--- a/src/main/java/at/ac/tuwien/kr/alpha/config/CommandLineParser.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/config/CommandLineParser.java
@@ -74,7 +74,7 @@ public class CommandLineParser {
 	private static final Option OPT_LITERATE = Option.builder("l").longOpt("literate")
 			.desc("enable literate programming mode (default: " + InputConfig.DEFAULT_LITERATE + ")").build();
 	private static final Option OPT_WRITE_XSLX = Option.builder("wx").longOpt("write-xlsx").hasArg(true).argName("path").type(String.class)
-			.desc("Write answer sets to xlsx workbooks (one workbook per answer set)").build();
+			.desc("Write answer sets to excel files, i.e. xlsx workbooks (one workbook per answer set)").build();
 
 	// general system-wide config
 	private static final Option OPT_GROUNDER = Option.builder("g").longOpt("grounder").hasArg(true).argName("grounder")

--- a/src/main/java/at/ac/tuwien/kr/alpha/config/CommandLineParser.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/config/CommandLineParser.java
@@ -96,8 +96,8 @@ public class CommandLineParser {
 	private static final Option OPT_MOMS_STRATEGY = Option.builder("ms").longOpt("momsStrategy").hasArg(true).argName("strategy")
 			.desc("strategy for mom's heuristic (CountBinaryWatches or BinaryNoGoodPropagation, default: " + SystemConfig.DEFAULT_MOMS_STRATEGY.name() + ")")
 			.build();
-	private static final Option OPT_REPLAY_CHOICES = Option.builder("rc").longOpt("replayChoices").hasArg().argName("choices").desc(
-			"comma-separated list of choices to be replayed (each choice is represented by a signed integer whose absolute value designates an atom ID and whose sign designates a truth value)")
+	private static final Option OPT_REPLAY_CHOICES = Option.builder("rc").longOpt("replayChoices").hasArg().argName("choices")
+			.desc("comma-separated list of choices to be replayed (each choice is represented by a signed integer whose absolute value designates an atom ID and whose sign designates a truth value)")
 			.build();
 	private static final Option OPT_QUIET = Option.builder("q").longOpt("quiet").desc("do not print answer sets (default: " + SystemConfig.DEFAULT_QUIET)
 			.build();

--- a/src/main/java/at/ac/tuwien/kr/alpha/config/CommandLineParser.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/config/CommandLineParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016-2019, the Alpha Team.
+ * Copyright (c) 2016-2020, the Alpha Team.
  * All rights reserved.
  *
  * Additional changes made by Siemens.

--- a/src/main/java/at/ac/tuwien/kr/alpha/config/CommandLineParser.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/config/CommandLineParser.java
@@ -60,6 +60,7 @@ public class CommandLineParser {
 	 * to the handler.
 	 */
 	// "special", i.e. non-configuration options
+	//@formatter:off
 	private static final Option OPT_HELP = Option.builder("h").longOpt("help").hasArg(false).desc("shows this help").build();
 
 	// input-specific options
@@ -111,16 +112,22 @@ public class CommandLineParser {
 			.desc("use counting grid normalization instead of sorting circuit for #count (default: " + SystemConfig.DEFAULT_USE_NORMALIZATION_GRID + ")")
 			.build();
 	private static final Option OPT_NO_NOGOOD_DELETION = Option.builder("dnd").longOpt("disableNoGoodDeletion")
-			.desc("disable the deletion of (learned, little active) nogoods (default: " + SystemConfig.DEFAULT_DISABLE_NOGOOD_DELETION + ")").build();
+			.desc("disable the deletion of (learned, little active) nogoods (default: " 
+							+ SystemConfig.DEFAULT_DISABLE_NOGOOD_DELETION + ")")
+			.build();
 	private static final Option OPT_GROUNDER_TOLERANCE_CONSTRAINTS = Option.builder("gtc").longOpt("grounderToleranceConstraints")
-			.desc("grounder tolerance for constraints (default: " + SystemConfig.DEFAULT_GROUNDER_TOLERANCE_CONSTRAINTS + ")").hasArg().argName("tolerance")
+			.desc("grounder tolerance for constraints (default: " + SystemConfig.DEFAULT_GROUNDER_TOLERANCE_CONSTRAINTS + ")")
+			.hasArg().argName("tolerance")
 			.build();
 	private static final Option OPT_GROUNDER_TOLERANCE_RULES = Option.builder("gtr").longOpt("grounderToleranceRules")
-			.desc("grounder tolerance for rules (default: " + SystemConfig.DEFAULT_GROUNDER_TOLERANCE_RULES + ")").hasArg().argName("tolerance").build();
+			.desc("grounder tolerance for rules (default: " + SystemConfig.DEFAULT_GROUNDER_TOLERANCE_RULES + ")")
+			.hasArg().argName("tolerance")
+			.build();
 	private static final Option OPT_GROUNDER_ACCUMULATOR_ENABLED = Option.builder("acc").longOpt("enableAccumulator")
 			.desc("activates the accumulator grounding strategy by disabling removal of instances from grounder memory in certain cases (default: "
-					+ SystemConfig.DEFAULT_GROUNDER_ACCUMULATOR_ENABLED + ")")
+						+ SystemConfig.DEFAULT_GROUNDER_ACCUMULATOR_ENABLED + ")")
 			.build();
+	//@formatter:on
 
 	private static final Options CLI_OPTS = new Options();
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/config/InputConfig.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/config/InputConfig.java
@@ -15,6 +15,8 @@ public class InputConfig {
 	public static final java.util.function.Predicate<Predicate> DEFAULT_FILTER = p -> true;
 	public static final boolean DEFAULT_LITERATE = false;
 	public static final int DEFAULT_NUM_ANSWER_SETS = 0;
+	public static final boolean DEFAULT_WRITE_XLSX = false;
+	public static final String DEFAULT_OUTFILE_PATH = "alphaAnswerSet"; // current directory, files named "alphaAnswerSet.{num}.{ext}"
 
 	private List<String> aspStrings = new ArrayList<>();
 	private List<String> files = new ArrayList<>();
@@ -22,6 +24,8 @@ public class InputConfig {
 	private int numAnswerSets = InputConfig.DEFAULT_NUM_ANSWER_SETS;
 	private Set<String> desiredPredicates = new HashSet<>();
 	private Map<String, PredicateInterpretation> predicateMethods = new HashMap<>();
+	private boolean writeAnswerSetsAsXlsx = InputConfig.DEFAULT_WRITE_XLSX;
+	private String answerSetFileOutputPath;
 
 	public static InputConfig forString(String str) {
 		InputConfig retVal = new InputConfig();
@@ -83,6 +87,22 @@ public class InputConfig {
 
 	public void setDesiredPredicates(Set<String> desiredPredicates) {
 		this.desiredPredicates = desiredPredicates;
+	}
+
+	public boolean isWriteAnswerSetsAsXlsx() {
+		return this.writeAnswerSetsAsXlsx;
+	}
+
+	public void setWriteAnswerSetsAsXlsx(boolean writeAnswerSetsAsXslx) {
+		this.writeAnswerSetsAsXlsx = writeAnswerSetsAsXslx;
+	}
+
+	public String getAnswerSetFileOutputPath() {
+		return this.answerSetFileOutputPath;
+	}
+
+	public void setAnswerSetFileOutputPath(String answerSetFileOutputPath) {
+		this.answerSetFileOutputPath = answerSetFileOutputPath;
 	}
 
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/AlphaTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/AlphaTest.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import at.ac.tuwien.kr.alpha.api.Alpha;
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
 import at.ac.tuwien.kr.alpha.common.AnswerSetBuilder;
 import at.ac.tuwien.kr.alpha.common.DisjunctiveHead;

--- a/src/test/java/at/ac/tuwien/kr/alpha/AnswerSetToXlsxWriterTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/AnswerSetToXlsxWriterTest.java
@@ -1,0 +1,33 @@
+package at.ac.tuwien.kr.alpha;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import at.ac.tuwien.kr.alpha.common.AnswerSet;
+import at.ac.tuwien.kr.alpha.common.AnswerSetBuilder;
+
+public class AnswerSetToXlsxWriterTest {
+
+	@Test
+	public void writeAnswerSetFilesTest() throws IOException {
+		AnswerSet as = new AnswerSetBuilder().predicate("bla").instance("blubb", "blubb").instance("foo", "bar").predicate("foo").instance("bar")
+				.instance("baz").predicate("complex").instance(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3)).build();
+		Path tmpDir = Files.createTempDirectory("alpha-test-xlsx-output");
+		AnswerSetToXlsxWriter writer = new AnswerSetToXlsxWriter(tmpDir.toString() + "/alphaAnswerSet");
+		writer.accept(0, as);
+		File tmpDirFile = tmpDir.toFile();
+		File[] generatedFiles = tmpDirFile.listFiles();
+		Assert.assertEquals(generatedFiles.length, 1);
+		File answerSetFile = generatedFiles[0];
+		Assert.assertEquals("alphaAnswerSet.0.xlsx", answerSetFile.getName());
+		// clean up
+		answerSetFile.delete();
+		tmpDirFile.delete();
+	}
+
+}

--- a/src/test/java/at/ac/tuwien/kr/alpha/AnswerSetToXlsxWriterTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/AnswerSetToXlsxWriterTest.java
@@ -4,7 +4,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.junit.Assert;
@@ -30,8 +33,31 @@ public class AnswerSetToXlsxWriterTest {
 		Assert.assertEquals("alphaAnswerSet.0.xlsx", answerSetFile.getName());
 		Workbook wb = WorkbookFactory.create(answerSetFile);
 		AnswerSetToWorkbookMapperTest.assertWorkbookMatchesAnswerSet(wb, as);
+		wb.close();
 		// clean up
 		answerSetFile.delete();
+		tmpDirFile.delete();
+	}
+
+	@Test
+	public void writeUnsatTest() throws IOException {
+		Path tmpDir = Files.createTempDirectory("alpha-test-xlsx-unsat");
+		AnswerSetToXlsxWriter.writeUnsatInfo(Paths.get(tmpDir.toString() + "/alphaAnswerSet.UNSAT.xlsx"));
+		File tmpDirFile = tmpDir.toFile();
+		File[] generatedFiles = tmpDirFile.listFiles();
+		Assert.assertEquals(generatedFiles.length, 1);
+		File unsatFile = generatedFiles[0];
+		Assert.assertEquals("alphaAnswerSet.UNSAT.xlsx", unsatFile.getName());
+		Workbook wb = WorkbookFactory.create(unsatFile);
+		Sheet unsatSheet = wb.getSheet("Unsatisfiable");
+		Assert.assertNotNull(unsatSheet);
+		Cell cell = unsatSheet.getRow(0).getCell(0);
+		Assert.assertNotNull(cell);
+		String cellValue = cell.getStringCellValue();
+		Assert.assertEquals("Input is unsatisfiable - No answer sets!", cellValue);
+		wb.close();
+		// clean up
+		unsatFile.delete();
 		tmpDirFile.delete();
 	}
 

--- a/src/test/java/at/ac/tuwien/kr/alpha/AnswerSetToXlsxWriterTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/AnswerSetToXlsxWriterTest.java
@@ -5,9 +5,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
+import at.ac.tuwien.kr.alpha.api.mapper.impl.AnswerSetToWorkbookMapperTest;
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
 import at.ac.tuwien.kr.alpha.common.AnswerSetBuilder;
 
@@ -25,6 +28,8 @@ public class AnswerSetToXlsxWriterTest {
 		Assert.assertEquals(generatedFiles.length, 1);
 		File answerSetFile = generatedFiles[0];
 		Assert.assertEquals("alphaAnswerSet.0.xlsx", answerSetFile.getName());
+		Workbook wb = WorkbookFactory.create(answerSetFile);
+		AnswerSetToWorkbookMapperTest.assertWorkbookMatchesAnswerSet(wb, as);
 		// clean up
 		answerSetFile.delete();
 		tmpDirFile.delete();

--- a/src/test/java/at/ac/tuwien/kr/alpha/api/AlphaTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/api/AlphaTest.java
@@ -25,7 +25,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package at.ac.tuwien.kr.alpha;
+package at.ac.tuwien.kr.alpha.api;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import at.ac.tuwien.kr.alpha.api.Alpha;
+import at.ac.tuwien.kr.alpha.AnswerSetsParser;
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
 import at.ac.tuwien.kr.alpha.common.AnswerSetBuilder;
 import at.ac.tuwien.kr.alpha.common.DisjunctiveHead;

--- a/src/test/java/at/ac/tuwien/kr/alpha/api/mapper/impl/AnswerSetToWorkbookMapperTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/api/mapper/impl/AnswerSetToWorkbookMapperTest.java
@@ -1,0 +1,98 @@
+package at.ac.tuwien.kr.alpha.api.mapper.impl;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.junit.Assert;
+import org.junit.Test;
+
+import at.ac.tuwien.kr.alpha.api.Alpha;
+import at.ac.tuwien.kr.alpha.common.AnswerSet;
+import at.ac.tuwien.kr.alpha.common.AnswerSetBuilder;
+import at.ac.tuwien.kr.alpha.common.Predicate;
+import at.ac.tuwien.kr.alpha.common.atoms.Atom;
+import at.ac.tuwien.kr.alpha.common.terms.Term;
+
+public class AnswerSetToWorkbookMapperTest {
+
+	private AnswerSetToWorkbookMapper mapper = new AnswerSetToWorkbookMapper();
+
+	@Test
+	public void smokeTest() throws IOException {
+		AnswerSet as = new AnswerSetBuilder().predicate("bla").instance("blubb", "blubb").instance("foo", "bar").predicate("foo").instance("bar")
+				.instance("baz").predicate("complex").instance(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3)).build();
+		Workbook wb = this.mapper.mapFromAnswerSet(as);
+		Assert.assertNotNull(wb.getSheet("Flags"));
+		Assert.assertNotNull(wb.getSheet("bla_2"));
+		Assert.assertNotNull(wb.getSheet("foo_1"));
+		Assert.assertNotNull(wb.getSheet("complex_3"));
+		wb.close();
+	}
+
+	@Test
+	public void solveAndWriteWorkbookTest() {
+		//@formatter:off
+		String progstr = "aFlag. oneMoreFlag. yetAnotherFlag. createPs. maxP(5). r(s(1, 2, 3), 4). r(bla, blubb). r(foo, bar(baaz))."
+				+ "p(0) :- createPs. "
+				+ "p(N) :- p(I), N = I + 1, N <= MX, maxP(MX)."
+				+ "q(A, B) :- p(A), p(B).";
+		//@formatter:on
+		Alpha alpha = new Alpha();
+		List<AnswerSet> answerSets = alpha.solve(alpha.readProgramString(progstr, null)).collect(Collectors.toList());
+		Assert.assertEquals(1, answerSets.size());
+		AnswerSet as = answerSets.get(0);
+		Workbook answerSetWorkbook = this.mapper.mapFromAnswerSet(as);
+		AnswerSetToWorkbookMapperTest.assertWorkbookMatchesAnswerSet(answerSetWorkbook, as);
+	}
+
+	private static void assertWorkbookMatchesAnswerSet(Workbook wb, AnswerSet as) {
+		for (Predicate pred : as.getPredicates()) {
+			if (pred.getArity() == 0) {
+				boolean flagFound = false;
+				Sheet flagsSheet = wb.getSheet("Flags");
+				Assert.assertNotNull(flagsSheet);
+				for (Row row : flagsSheet) {
+					if (row.getCell(0).getStringCellValue().equals(pred.getName())) {
+						flagFound = true;
+						break;
+					}
+				}
+				Assert.assertTrue("0-arity predicate " + pred.getName() + " not found in workbook!", flagFound);
+			} else {
+				Sheet predicateSheet = wb.getSheet(pred.getName() + "_" + pred.getArity());
+				for (Atom atom : as.getPredicateInstances(pred)) {
+					boolean atomFound = false;
+					Assert.assertNotNull(predicateSheet);
+					for (Row row : predicateSheet) {
+						if (AnswerSetToWorkbookMapperTest.rowMatchesAtom(row, atom)) {
+							atomFound = true;
+							break;
+						}
+					}
+					Assert.assertTrue("Atom " + atom.toString() + " not found in workbook!", atomFound);
+				}
+			}
+		}
+	}
+
+	private static boolean rowMatchesAtom(Row row, Atom atom) {
+		List<Term> terms = atom.getTerms();
+		Cell cell;
+		for (int i = 0; i < terms.size(); i++) {
+			cell = row.getCell(i);
+			if (cell == null) {
+				return false;
+			}
+			if (!(cell.getStringCellValue().equals(terms.get(i).toString()))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+}

--- a/src/test/java/at/ac/tuwien/kr/alpha/api/mapper/impl/AnswerSetToWorkbookMapperTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/api/mapper/impl/AnswerSetToWorkbookMapperTest.java
@@ -50,7 +50,7 @@ public class AnswerSetToWorkbookMapperTest {
 		AnswerSetToWorkbookMapperTest.assertWorkbookMatchesAnswerSet(answerSetWorkbook, as);
 	}
 
-	private static void assertWorkbookMatchesAnswerSet(Workbook wb, AnswerSet as) {
+	public static void assertWorkbookMatchesAnswerSet(Workbook wb, AnswerSet as) {
 		for (Predicate pred : as.getPredicates()) {
 			if (pred.getArity() == 0) {
 				boolean flagFound = false;


### PR DESCRIPTION
In order to aid data exploration and visualization, this PR introduces a new feature, allowing answer sets to be written as xlsx files rather than just printed to stdout.

## API Changes and Additions
* new package `at.ac.tuwien.kr.alpha.api` as top-level package for public API types (such as `Alpha.java`)
* Interface `AnswerSetToObjectMapper<T>` defining a mapping function from `AnswerSet` to a type parameter `T`
* Mapper implementation to map from `AnswerSet` to `Workbook`, i.e. xlsx workbooks. Implementation is realized using [Apache POI](https://poi.apache.org/) using the approach outlined [here](https://www.callicoder.com/java-write-excel-file-apache-poi/)

## Commandline-Interface
* New argument `-wx <path>`: When set,  answer sets will be written to xlsx files at the given path, e.g. the call `java -jar alpha.jar -i prog.asp -wx /some/dir/progAnswerSet` will result in the first answer set being written to  `/some/dir/progAnswerSet.1.xlsx`, the second answer set to `/some/dir/progAnswerSet.2.xlsx` etc.

## XLSX Workbook structure
* One worksheet (i.e. "tab") for each predicate with arity greater zero
* One worksheet "Flags" listing all predicates with arity zero
* In predicate-specific worksheets, each row corresponds to one atom, where columns correspond to the terms of the atom in question