### PR TITLE
Fix bug in justification analysis, address issue #211.

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/Unifier.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/Unifier.java
@@ -47,6 +47,18 @@ public class Unifier extends Substitution {
 		return this;
 	}
 
+	/**
+	 * Returns a list of all variables that this unifier maps to something else, i.e., it returns all variables on the left-hand side of the unifier.
+	 * @return the list of mapped variables.
+	 */
+	public List<Term> getMappedVariables() {
+		ArrayList<Term> ret = new ArrayList<>();
+		for (Map.Entry<VariableTerm, Term> substitution : substitution.entrySet()) {
+			ret.add(substitution.getKey());
+		}
+		return ret;
+	}
+
 
 	public <T extends Comparable<T>> Term put(VariableTerm variableTerm, Term term) {
 		// If term is not ground, store it for right-hand side reverse-lookup.

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/Unifier.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/Unifier.java
@@ -48,13 +48,14 @@ public class Unifier extends Substitution {
 	}
 
 	/**
-	 * Returns a list of all variables that this unifier maps to something else, i.e., it returns all variables on the left-hand side of the unifier.
-	 * @return the list of mapped variables.
+	 * Returns a list of all variables occurring in that unifier, i.e., variables that are mapped and those that occur (nested) in the right-hand side of the unifier.
+	 * @return the list of variables occurring somewhere in the unifier.
 	 */
-	public List<Term> getMappedVariables() {
+	public List<Term> getOccurringVariables() {
 		ArrayList<Term> ret = new ArrayList<>();
 		for (Map.Entry<VariableTerm, Term> substitution : substitution.entrySet()) {
 			ret.add(substitution.getKey());
+			ret.addAll(substitution.getValue().getOccurringVariables());
 		}
 		return ret;
 	}

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/Unifier.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/Unifier.java
@@ -13,7 +13,7 @@ import static at.ac.tuwien.kr.alpha.Util.oops;
 /**
  * A variable substitution allowing variables to occur on the right-hand side. Chains of variable substitutions are
  * resolved automatically, i.e., adding the substitutions (X -> A) and (A -> d) results in (X -> d), (A -> d).
- * Copyright (c) 2018, the Alpha Team.
+ * Copyright (c) 2018-2020, the Alpha Team.
  */
 public class Unifier extends Substitution {
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/structure/AnalyzeUnjustified.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/structure/AnalyzeUnjustified.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import static at.ac.tuwien.kr.alpha.Util.oops;
 
 /**
- * Copyright (c) 2018, the Alpha Team.
+ * Copyright (c) 2018-2020, the Alpha Team.
  */
 public class AnalyzeUnjustified {
 	private static final Logger LOGGER = LoggerFactory.getLogger(AnalyzeUnjustified.class);

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/structure/AnalyzeUnjustified.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/structure/AnalyzeUnjustified.java
@@ -1,13 +1,34 @@
 package at.ac.tuwien.kr.alpha.grounder.structure;
 
-import at.ac.tuwien.kr.alpha.common.*;
-import at.ac.tuwien.kr.alpha.common.atoms.*;
-import at.ac.tuwien.kr.alpha.grounder.*;
+import at.ac.tuwien.kr.alpha.common.Assignment;
+import at.ac.tuwien.kr.alpha.common.AtomStore;
+import at.ac.tuwien.kr.alpha.common.DisjunctiveHead;
+import at.ac.tuwien.kr.alpha.common.Predicate;
+import at.ac.tuwien.kr.alpha.common.Rule;
+import at.ac.tuwien.kr.alpha.common.atoms.Atom;
+import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
+import at.ac.tuwien.kr.alpha.common.atoms.ComparisonLiteral;
+import at.ac.tuwien.kr.alpha.common.atoms.FixedInterpretationLiteral;
+import at.ac.tuwien.kr.alpha.common.atoms.Literal;
+import at.ac.tuwien.kr.alpha.common.terms.Term;
+import at.ac.tuwien.kr.alpha.grounder.Instance;
+import at.ac.tuwien.kr.alpha.grounder.NonGroundRule;
+import at.ac.tuwien.kr.alpha.grounder.Unification;
+import at.ac.tuwien.kr.alpha.grounder.Unifier;
 import at.ac.tuwien.kr.alpha.solver.ThriceTruth;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
 import static at.ac.tuwien.kr.alpha.Util.oops;
 
@@ -219,10 +240,15 @@ public class AnalyzeUnjustified {
 				if (!bSigma.isGround()) {
 					throw oops("Resulting atom is not ground.");
 				}
+				List<Term> variablesMappedBySigma = sigma.getMappedVariables();
 				if (Unification.instantiate(bSigmaY, bSigma) != null) {
 					for (Unifier sigmaN : vN) {
-						if (Unification.instantiate(b.substitute(sigmaN), bSigma) != null) {
-							log("Atom is excluded by: {}", sigmaN);
+						ArrayList<Term> occurringVariables = new ArrayList<>(variablesMappedBySigma);
+						occurringVariables.addAll(sigmaN.getMappedVariables());
+						BasicAtom genericAtom = new BasicAtom(Predicate.getInstance("_", occurringVariables.size(), true), occurringVariables);
+						BasicAtom genericSubstituted = genericAtom.substitute(sigmaN);
+						if (Unification.instantiate(genericSubstituted, genericAtom.substitute(sigma)) != null) {
+							log("Atom {} is excluded by: {} via {}", genericSubstituted, sigmaN, sigma);
 							continue atomLoop;
 						}
 					}

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/structure/AnalyzeUnjustified.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/structure/AnalyzeUnjustified.java
@@ -240,13 +240,13 @@ public class AnalyzeUnjustified {
 				if (!bSigma.isGround()) {
 					throw oops("Resulting atom is not ground.");
 				}
-				List<Term> variablesMappedBySigma = sigma.getMappedVariables();
+				List<Term> variablesOccurringInSigma = sigma.getOccurringVariables();
 				if (Unification.instantiate(bSigmaY, bSigma) != null) {
 					for (Unifier sigmaN : vN) {
-						ArrayList<Term> occurringVariables = new ArrayList<>(variablesMappedBySigma);
-						occurringVariables.addAll(sigmaN.getMappedVariables());
+						ArrayList<Term> occurringVariables = new ArrayList<>(variablesOccurringInSigma);
+						occurringVariables.addAll(sigmaN.getOccurringVariables());
 						BasicAtom genericAtom = new BasicAtom(Predicate.getInstance("_", occurringVariables.size(), true), occurringVariables);
-						BasicAtom genericSubstituted = genericAtom.substitute(sigmaN);
+						Atom genericSubstituted = genericAtom.substitute(sigmaN).renameVariables("_analyzeTest");
 						if (Unification.instantiate(genericSubstituted, genericAtom.substitute(sigma)) != null) {
 							log("Atom {} is excluded by: {} via {}", genericSubstituted, sigmaN, sigma);
 							continue atomLoop;


### PR DESCRIPTION
Justification analysis used erroneously specific atom to test whether a given substitution is excluded by a more general one. Now a more general atom is constructed for the test. This fixes issue #211, this fix/PR is independent of the phase saving and restarts branch as the bug was just unearthed there but is present in master, too.