### PR TITLE
Deprecate old domain-independent heuristics

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/heuristics/BranchingHeuristicFactory.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/heuristics/BranchingHeuristicFactory.java
@@ -37,6 +37,11 @@ import java.util.stream.Collectors;
 
 public final class BranchingHeuristicFactory {
 
+	/**
+	 * The available domain-independent heuristics.
+	 * Some are deprecated because they perform poorly and have not been improved for some time,
+	 * however the code is kept for now so that it stays compatible when interfaces are refactored.
+	 */
 	public enum Heuristic {
 		NAIVE,
 		BERKMIN,

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/heuristics/BranchingHeuristicFactory.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/heuristics/BranchingHeuristicFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2017-2019 Siemens AG
+/*
+ * Copyright (c) 2017-2020 Siemens AG
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -41,19 +41,33 @@ public final class BranchingHeuristicFactory {
 		NAIVE,
 		BERKMIN,
 		BERKMINLITERAL,
+		@Deprecated
 		DD,
+		@Deprecated
 		DD_SUM,
+		@Deprecated
 		DD_AVG,
+		@Deprecated
 		DD_MAX,
+		@Deprecated
 		DD_MIN,
+		@Deprecated
 		DD_PYRO,
+		@Deprecated
 		GDD,
+		@Deprecated
 		GDD_SUM,
+		@Deprecated
 		GDD_AVG,
+		@Deprecated
 		GDD_MAX,
+		@Deprecated
 		GDD_MIN,
+		@Deprecated
 		GDD_PYRO,
+		@Deprecated
 		ALPHA_ACTIVE_RULE,
+		@Deprecated
 		ALPHA_HEAD_MBT,
 		VSIDS,
 		GDD_VSIDS;

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/AbstractSolverTests.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/AbstractSolverTests.java
@@ -53,13 +53,11 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.emptySet;
 import static org.junit.Assert.assertEquals;
@@ -67,15 +65,15 @@ import static org.junit.Assert.assertEquals;
 @RunWith(Parameterized.class)
 public abstract class AbstractSolverTests {
 
-	private static final Collection<Heuristic> NON_DEPRECATED_HEURISTICS;
+	private static final String[] NON_DEPRECATED_HEURISTICS_NAMES;
 	static {
-		final List<Heuristic> nonDeprecatedHeuristics = new ArrayList<>();
+		final List<String> nonDeprecatedHeuristicsNames = new ArrayList<>();
 		for (Field field : Heuristic.class.getFields()) {
 			if (field.getAnnotation(Deprecated.class) == null) {
-				nonDeprecatedHeuristics.add(Heuristic.valueOf(field.getName()));
+				nonDeprecatedHeuristicsNames.add(field.getName());
 			}
 		}
-		NON_DEPRECATED_HEURISTICS = Collections.unmodifiableCollection(nonDeprecatedHeuristics);
+		NON_DEPRECATED_HEURISTICS_NAMES = nonDeprecatedHeuristicsNames.toArray(new String[]{});
 	}
 
 	private final ProgramParser parser = new ProgramParser();
@@ -138,7 +136,7 @@ public abstract class AbstractSolverTests {
 		}
 		// "NON_DEPRECATED" is a magic value that will be expanded to contain all non-deprecated heuristics.
 		if ("NON_DEPRECATED".equals(heuristics[0])) {
-			heuristics = NON_DEPRECATED_HEURISTICS.stream().map(Heuristic::name).collect(Collectors.toList()).toArray(heuristics);
+			heuristics = NON_DEPRECATED_HEURISTICS_NAMES;
 		}
 
 		// NOTE:

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/AbstractSolverTests.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/AbstractSolverTests.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2017-2019, the Alpha Team.
+/*
+ * Copyright (c) 2017-2020, the Alpha Team.
  * All rights reserved.
  *
  * Additional changes made by Siemens.
@@ -37,6 +37,7 @@ import at.ac.tuwien.kr.alpha.grounder.Grounder;
 import at.ac.tuwien.kr.alpha.grounder.GrounderFactory;
 import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
 import at.ac.tuwien.kr.alpha.solver.heuristics.BranchingHeuristicFactory;
+import at.ac.tuwien.kr.alpha.solver.heuristics.BranchingHeuristicFactory.Heuristic;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import org.antlr.v4.runtime.CharStream;
@@ -48,19 +49,35 @@ import org.junit.runners.Parameterized.Parameters;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptySet;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public abstract class AbstractSolverTests {
+
+	private static final Collection<Heuristic> NON_DEPRECATED_HEURISTICS;
+	static {
+		final List<Heuristic> nonDeprecatedHeuristics = new ArrayList<>();
+		for (Field field : Heuristic.class.getFields()) {
+			if (field.getAnnotation(Deprecated.class) == null) {
+				nonDeprecatedHeuristics.add(Heuristic.valueOf(field.getName()));
+			}
+		}
+		NON_DEPRECATED_HEURISTICS = Collections.unmodifiableCollection(nonDeprecatedHeuristics);
+	}
+
 	private final ProgramParser parser = new ProgramParser();
 
 	/**
@@ -105,7 +122,7 @@ public abstract class AbstractSolverTests {
 		String[] solvers = getProperty("solvers", ci ? "default,naive" : "default");
 		String[] grounders = getProperty("grounders", "naive");
 		String[] stores = getProperty("stores", ci ? "alpharoaming,naive" : "alpharoaming");
-		String[] heuristics = getProperty("heuristics", ci ? "ALL" : "NAIVE,VSIDS");
+		String[] heuristics = getProperty("heuristics", ci ? "NON_DEPRECATED" : "NAIVE,VSIDS");
 		String[] gtcValues = getProperty("grounderToleranceConstraints", "strict,permissive");
 		String[] gtrValues = getProperty("grounderToleranceRules", "strict");
 		String[] dirValues = getProperty("disableInstanceRemoval", ci ? "false,true" : "false");
@@ -118,6 +135,10 @@ public abstract class AbstractSolverTests {
 			for (BranchingHeuristicFactory.Heuristic heuristic : values) {
 				heuristics[i++] = heuristic.toString();
 			}
+		}
+		// "NON_DEPRECATED" is a magic value that will be expanded to contain all non-deprecated heuristics.
+		if ("NON_DEPRECATED".equals(heuristics[0])) {
+			heuristics = NON_DEPRECATED_HEURISTICS.stream().map(Heuristic::name).collect(Collectors.toList()).toArray(heuristics);
 		}
 
 		// NOTE:


### PR DESCRIPTION
Deprecate old domain-independent heuristics, and run solver tests only for non-deprecated heuristics.
The reason is that these old heuristics have not been maintained for a while and often perform poorly (#181). Sometimes they make CI break because tests take too much time using those heuristics.