### PR TITLE
Avoiding Integer objects.

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/common/Assignment.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/Assignment.java
@@ -30,7 +30,6 @@ package at.ac.tuwien.kr.alpha.common;
 import at.ac.tuwien.kr.alpha.solver.Antecedent;
 import at.ac.tuwien.kr.alpha.solver.ThriceTruth;
 
-import java.util.Iterator;
 import java.util.Set;
 
 import static at.ac.tuwien.kr.alpha.common.Literals.atomOf;
@@ -91,7 +90,7 @@ public interface Assignment {
 	 * Returns an iterator over all newly assigned atoms. New assignments are only returned once.
 	 * @return an iterator over all atoms newly assigned to TRUE or MBT.
 	 */
-	Iterator<Integer> getNewPositiveAssignmentsIterator();
+	IntIterator getNewPositiveAssignmentsIterator();
 
 	/**
 	 * Returns the new assignments to process.

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/IntIterator.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/IntIterator.java
@@ -1,0 +1,20 @@
+package at.ac.tuwien.kr.alpha.common;
+
+/**
+ * An iterator returning raw int integers instead of Integer objects (for efficiency).
+ *
+ * Copyright (c) 2020, the Alpha Team.
+ */
+public interface IntIterator {
+
+	/**
+	 * @return true if the iterator has more elements.
+	 */
+	public abstract boolean hasNext();
+
+	/**
+	 * @return the next int in the iteration.
+	 */
+	public abstract int next();
+
+}

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/IntIterator.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/IntIterator.java
@@ -10,11 +10,11 @@ public interface IntIterator {
 	/**
 	 * @return true if the iterator has more elements.
 	 */
-	public abstract boolean hasNext();
+	boolean hasNext();
 
 	/**
 	 * @return the next int in the iteration.
 	 */
-	public abstract int next();
+	int next();
 
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/Grounder.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/Grounder.java
@@ -29,11 +29,11 @@ package at.ac.tuwien.kr.alpha.grounder;
 
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
 import at.ac.tuwien.kr.alpha.common.Assignment;
+import at.ac.tuwien.kr.alpha.common.IntIterator;
 import at.ac.tuwien.kr.alpha.common.NoGood;
 import at.ac.tuwien.kr.alpha.grounder.atoms.RuleAtom;
 import org.apache.commons.lang3.tuple.Pair;
 
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -64,7 +64,7 @@ public interface Grounder {
 	 * Updates the grounder with atoms assigned a positive truth value.
 	 * @param it an iterator over all newly assigned positive atoms.
 	 */
-	void updateAssignment(Iterator<Integer> it);
+	void updateAssignment(IntIterator it);
 
 	/**
 	 * Returns a set of new mappings from head atoms to {@link RuleAtom}s deriving it.

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
@@ -31,6 +31,7 @@ import at.ac.tuwien.kr.alpha.common.AnswerSet;
 import at.ac.tuwien.kr.alpha.common.Assignment;
 import at.ac.tuwien.kr.alpha.common.AtomStore;
 import at.ac.tuwien.kr.alpha.common.BasicAnswerSet;
+import at.ac.tuwien.kr.alpha.common.IntIterator;
 import at.ac.tuwien.kr.alpha.common.NoGood;
 import at.ac.tuwien.kr.alpha.common.NoGoodInterface;
 import at.ac.tuwien.kr.alpha.common.Predicate;
@@ -81,7 +82,7 @@ import static java.util.Collections.singletonList;
 
 /**
  * A semi-naive grounder.
- * Copyright (c) 2016-2019, the Alpha Team.
+ * Copyright (c) 2016-2020, the Alpha Team.
  */
 public class NaiveGrounder extends BridgedGrounder implements ProgramAnalyzingGrounder {
 	private static final Logger LOGGER = LoggerFactory.getLogger(NaiveGrounder.class);
@@ -692,7 +693,7 @@ public class NaiveGrounder extends BridgedGrounder implements ProgramAnalyzingGr
 	}
 
 	@Override
-	public void updateAssignment(Iterator<Integer> it) {
+	public void updateAssignment(IntIterator it) {
 		while (it.hasNext()) {
 			workingMemory.addInstance(atomStore.get(it.next()), true);
 		}

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/ChoiceInfluenceManager.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/ChoiceInfluenceManager.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
+import static at.ac.tuwien.kr.alpha.Util.arrayGrowthSize;
 import static at.ac.tuwien.kr.alpha.Util.oops;
 import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.MBT;
 import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.TRUE;
@@ -40,6 +41,7 @@ import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.TRUE;
 /**
  * Manages influence of atoms on the activity of certain other atoms. Can be used for either choice points or heuristic atoms.
  *
+ * Copyright (c) 2020, the Alpha Team.
  */
 public class ChoiceInfluenceManager implements Checkable {
 	
@@ -48,7 +50,7 @@ public class ChoiceInfluenceManager implements Checkable {
 	// Active choice points and all atoms that influence a choice point (enabler, disabler, choice atom itself).
 	private final Set<ChoicePoint> activeChoicePoints = new LinkedHashSet<>();
 	private final Set<Integer> activeChoicePointsAtoms = new LinkedHashSet<>();
-	private final Map<Integer, ChoicePoint> influencers = new HashMap<>();
+	private ChoicePoint[] influencers = new ChoicePoint[0];
 	private ActivityListener activityListener;
 
 	private final WritableAssignment assignment;
@@ -78,7 +80,7 @@ public class ChoiceInfluenceManager implements Checkable {
 		if (atom == null) {
 			throw oops("Incomplete choice point description found (no atom)");
 		}
-		if (influencers.get(atom) != null) {
+		if (influencers[atom] != null) {
 			throw oops("Received choice information repeatedly");
 		}
 		Integer enabler = atomToEnabler.getValue();
@@ -90,15 +92,19 @@ public class ChoiceInfluenceManager implements Checkable {
 		assignment.registerCallbackOnChange(enabler);
 		assignment.registerCallbackOnChange(disabler);
 		ChoicePoint choicePoint = new ChoicePoint(atom, enabler, disabler);
-		influencers.put(atom, choicePoint);
-		influencers.put(enabler, choicePoint);
-		influencers.put(disabler, choicePoint);
+		influencers[atom] = choicePoint;
+		influencers[enabler] = choicePoint;
+		influencers[disabler] = choicePoint;
 		choicePoint.recomputeActive();
 	}
 
 	void checkActiveChoicePoints() {
 		HashSet<ChoicePoint> actualActiveChoicePoints = new HashSet<>();
-		for (ChoicePoint choicePoint : influencers.values()) {
+		for (int i = 0; i < influencers.length; i++) {
+			ChoicePoint choicePoint = influencers[i];
+			if (choicePoint == null) {
+				continue;
+			}
 			if (checkActiveChoicePoint(choicePoint)) {
 				actualActiveChoicePoints.add(choicePoint);
 			}
@@ -123,7 +129,7 @@ public class ChoiceInfluenceManager implements Checkable {
 		if (checksEnabled) {
 			checkActiveChoicePoints();
 		}
-		ChoicePoint choicePoint = influencers.get(atom);
+		ChoicePoint choicePoint = influencers[atom];
 		return choicePoint != null && choicePoint.isActive && choicePoint.atom == atom;
 	}
 
@@ -135,7 +141,7 @@ public class ChoiceInfluenceManager implements Checkable {
 	}
 
 	boolean isAtomInfluenced(int atom) {
-		ChoicePoint choicePoint = influencers.get(atom);
+		ChoicePoint choicePoint = influencers[atom];
 		return choicePoint != null && choicePoint.atom == atom;
 	}
 
@@ -145,11 +151,26 @@ public class ChoiceInfluenceManager implements Checkable {
 	}
 
 	void callbackOnChanged(int atom) {
-		LOGGER.trace("Callback received on influencer atom: {}", atom);
-		ChoicePoint choicePoint = influencers.get(atom);
+		if (LOGGER.isTraceEnabled()) {
+			LOGGER.trace("Callback received on influencer atom: {}", atom);
+		}
+		ChoicePoint choicePoint = influencers[atom];
 		if (choicePoint != null) {
 			choicePoint.recomputeActive();
 		}
+	}
+
+	public void growForMaxAtomId(int maxAtomId) {
+		// Grow arrays only if needed.
+		if (influencers.length > maxAtomId) {
+			return;
+		}
+		// Grow to default size, except if bigger array is required due to maxAtomId.
+		int newCapacity = arrayGrowthSize(influencers.length);
+		if (newCapacity < maxAtomId + 1) {
+			newCapacity = maxAtomId + 1;
+		}
+		influencers = Arrays.copyOf(influencers, newCapacity);
 	}
 	
 	void setActivityListener(ActivityListener listener) {

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/ChoiceManager.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/ChoiceManager.java
@@ -234,6 +234,10 @@ public class ChoiceManager implements Checkable {
 		addHeadsToBodies(headsToBodies);
 	}
 
+	public void growForMaxAtomId(int maxAtomId) {
+		choicePointInfluenceManager.growForMaxAtomId(maxAtomId);
+	}
+
 	private void addHeadsToBodies(Map<Integer, Set<Integer>> headsToBodies) {
 		for (Entry<Integer, Set<Integer>> entry : headsToBodies.entrySet()) {
 			Integer head = entry.getKey();

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/DefaultSolver.java
@@ -75,7 +75,8 @@ import static at.ac.tuwien.kr.alpha.solver.learning.GroundConflictNoGoodLearner.
 
 /**
  * The new default solver employed in Alpha.
- * Copyright (c) 2016-2019, the Alpha Team.
+ *
+ * Copyright (c) 2016-2020, the Alpha Team.
  */
 public class DefaultSolver extends AbstractSolver implements SolverMaintainingStatistics {
 	private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSolver.class);
@@ -466,6 +467,7 @@ public class DefaultSolver extends AbstractSolver implements SolverMaintainingSt
 		assignment.growForMaxAtomId();
 		int maxAtomId = atomStore.getMaxAtomId();
 		store.growForMaxAtomId(maxAtomId);
+		choiceManager.growForMaxAtomId(maxAtomId);
 		branchingHeuristic.growForMaxAtomId(maxAtomId);
 		branchingHeuristic.newNoGoods(obtained.values());
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/NaiveSolver.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/NaiveSolver.java
@@ -29,6 +29,7 @@ package at.ac.tuwien.kr.alpha.solver;
 
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
 import at.ac.tuwien.kr.alpha.common.AtomStore;
+import at.ac.tuwien.kr.alpha.common.IntIterator;
 import at.ac.tuwien.kr.alpha.common.NoGood;
 import at.ac.tuwien.kr.alpha.grounder.Grounder;
 import org.apache.commons.lang3.tuple.Pair;
@@ -42,7 +43,7 @@ import static at.ac.tuwien.kr.alpha.common.Literals.*;
 import static java.lang.Math.abs;
 
 /**
- * Copyright (c) 2016, the Alpha Team.
+ * Copyright (c) 2016-2020, the Alpha Team.
  */
 public class NaiveSolver extends AbstractSolver {
 	private static final Logger LOGGER = LoggerFactory.getLogger(NaiveSolver.class);
@@ -277,8 +278,22 @@ public class NaiveSolver extends AbstractSolver {
 		}
 	}
 
+	private static IntIterator fromIterator(Iterator<Integer> it) {
+		return new IntIterator() {
+			@Override
+			public boolean hasNext() {
+				return it.hasNext();
+			}
+
+			@Override
+			public int next() {
+				return it.next();
+			}
+		};
+	}
+
 	private void updateGrounderAssignments() {
-		grounder.updateAssignment(newTruthAssignments.stream().filter(atom -> truthAssignments.get(atom)).iterator());
+		grounder.updateAssignment(fromIterator(newTruthAssignments.stream().filter(atom -> truthAssignments.get(atom)).iterator()));
 		newTruthAssignments.clear();
 	}
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/NoGoodStoreAlphaRoaming.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/NoGoodStoreAlphaRoaming.java
@@ -63,6 +63,8 @@ import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.TRUE;
  *  The second condition ensures that after backtracking the NoGood is still satisfied or both watches
  *  point to unassigned literals. Observe that for an assignment to TRUE the (potentially lower) decision level of MBT
  *  is taken.
+ *
+ *  Copyright (c) 2017-2020, the Alpha Team.
  */
 public class NoGoodStoreAlphaRoaming implements NoGoodStore, BinaryNoGoodPropagationEstimation, Checkable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(NoGoodStoreAlphaRoaming.class);
@@ -626,7 +628,9 @@ public class NoGoodStoreAlphaRoaming implements NoGoodStore, BinaryNoGoodPropaga
 			final int atom = assignmentsToProcess.peek();
 			final ThriceTruth currentTruth = assignment.getTruth(atom);
 			final int literal = atomToLiteral(atom, currentTruth.toBoolean());
-			LOGGER.trace("Propagation processing atom: {}={}", atom, currentTruth);
+			if (LOGGER.isTraceEnabled()) {
+				LOGGER.trace("Propagation processing atom: {}={}", atom, currentTruth);
+			}
 
 			// Propagate weakly, except if there is an earlier MBT, where propagation already took place.
 			if (currentTruth != TRUE || assignment.getWeakDecisionLevel(atom) == currentDecisionLevel) {
@@ -663,7 +667,7 @@ public class NoGoodStoreAlphaRoaming implements NoGoodStore, BinaryNoGoodPropaga
 		this.checksEnabled = checksEnabled;
 	}
 
-	private class BinaryWatchList {
+	class BinaryWatchList implements ShallowAntecedent {
 		private int[] noGoodsWithoutHead = new int[10];
 		private int noGoodsWithoutHeadSize;
 		private int[] noGoodsWithHead = new int[10];
@@ -698,7 +702,7 @@ public class NoGoodStoreAlphaRoaming implements NoGoodStore, BinaryNoGoodPropaga
 			ThriceTruth literalTruth = assignment.getTruth(atomOf(forLiteral));
 			if (literalTruth != null && literalTruth.toBoolean() == isPositive(forLiteral)) {
 				int weakDecisionLevel = assignment.getWeakDecisionLevel(atomOf(forLiteral));
-				ConflictCause conflictCause = assignment.assign(atomOf(otherLiteral), isPositive(otherLiteral) ? FALSE : MBT, new BinaryAntecedent(forLiteral, otherLiteral), weakDecisionLevel);
+				ConflictCause conflictCause = assignment.assign(atomOf(otherLiteral), isPositive(otherLiteral) ? FALSE : MBT, this, weakDecisionLevel);
 				if (conflictCause != null) {
 					return conflictCause;
 				}
@@ -706,7 +710,7 @@ public class NoGoodStoreAlphaRoaming implements NoGoodStore, BinaryNoGoodPropaga
 			// Assign head (strongly) if the newly added NoGood is unit.
 			int strongDecisionLevel = assignment.getStrongDecisionLevel(atomOf(forLiteral));
 			if (strongDecisionLevel != -1 && assignment.getTruth(atomOf(forLiteral)).toBoolean() == isPositive(forLiteral)) {
-				return assignment.assign(atomOf(otherLiteral), TRUE, new BinaryAntecedent(forLiteral, otherLiteral), strongDecisionLevel);
+				return assignment.assign(atomOf(otherLiteral), TRUE, this, strongDecisionLevel);
 			}
 			return null;
 		}
@@ -721,7 +725,7 @@ public class NoGoodStoreAlphaRoaming implements NoGoodStore, BinaryNoGoodPropaga
 			ThriceTruth literalTruth = assignment.getTruth(atomOf(forLiteral));
 			if (literalTruth != null && literalTruth.toBoolean() == isPositive(forLiteral)) {
 				int weakDecisionLevel = assignment.getWeakDecisionLevel(atomOf(forLiteral));
-				return assignment.assign(atomOf(otherLiteral), isPositive(otherLiteral) ? FALSE : MBT, new BinaryAntecedent(otherLiteral, forLiteral), weakDecisionLevel);
+				return assignment.assign(atomOf(otherLiteral), isPositive(otherLiteral) ? FALSE : MBT, this, weakDecisionLevel);
 			}
 			return null;
 		}
@@ -730,14 +734,14 @@ public class NoGoodStoreAlphaRoaming implements NoGoodStore, BinaryNoGoodPropaga
 			didPropagate |= noGoodsWithHeadSize > 0 || noGoodsWithoutHeadSize > 0;
 			for (int i = 0; i < noGoodsWithoutHeadSize; i++) {
 				final int otherLiteral = noGoodsWithoutHead[i];
-				ConflictCause conflictCause = assignment.assign(atomOf(otherLiteral), isPositive(otherLiteral) ? FALSE : MBT, new BinaryAntecedent(otherLiteral, forLiteral));
+				ConflictCause conflictCause = assignment.assign(atomOf(otherLiteral), isPositive(otherLiteral) ? FALSE : MBT, this);
 				if (conflictCause != null) {
 					return conflictCause;
 				}
 			}
 			for (int i = 0; i < noGoodsWithHeadSize; i++) {
 				final int otherLiteral = noGoodsWithHead[i];
-				ConflictCause conflictCause = assignment.assign(atomOf(otherLiteral), isPositive(otherLiteral) ? FALSE : MBT, new BinaryAntecedent(otherLiteral, forLiteral));
+				ConflictCause conflictCause = assignment.assign(atomOf(otherLiteral), isPositive(otherLiteral) ? FALSE : MBT, this);
 				if (conflictCause != null) {
 					return conflictCause;
 				}
@@ -749,7 +753,7 @@ public class NoGoodStoreAlphaRoaming implements NoGoodStore, BinaryNoGoodPropaga
 			didPropagate |= noGoodsWithHeadSize > 0;
 			for (int i = 0; i < noGoodsWithHeadSize; i++) {
 				final int headLiteral = noGoodsWithHead[i];
-				ConflictCause conflictCause = assignment.assign(atomOf(headLiteral), TRUE, new BinaryAntecedent(headLiteral, forLiteral));
+				ConflictCause conflictCause = assignment.assign(atomOf(headLiteral), TRUE, this);
 				if (conflictCause != null) {
 					return conflictCause;
 				}
@@ -764,6 +768,11 @@ public class NoGoodStoreAlphaRoaming implements NoGoodStore, BinaryNoGoodPropaga
 		@Override
 		public String toString() {
 			return "BinaryWatchList(" + forLiteral + ")";
+		}
+
+		@Override
+		public Antecedent instantiateAntecedent(int impliedLiteral) {
+			return new BinaryAntecedent(impliedLiteral, forLiteral);
 		}
 
 		private class BinaryAntecedent implements Antecedent {
@@ -827,7 +836,7 @@ public class NoGoodStoreAlphaRoaming implements NoGoodStore, BinaryNoGoodPropaga
 		return assignedNewly;
 	}
 
-	public void runInternalChecks() {
+	private void runInternalChecks() {
 		new WatchedNoGoodsChecker().doWatchesCheck();
 	}
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/ShallowAntecedent.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/ShallowAntecedent.java
@@ -1,0 +1,33 @@
+package at.ac.tuwien.kr.alpha.solver;
+
+import static at.ac.tuwien.kr.alpha.Util.oops;
+
+/**
+ * Represents a shallow {@link Antecedent} that must be instantiated before use.
+ *
+ * Copyright (c) 2020, the Alpha Team.
+ */
+public interface ShallowAntecedent extends Antecedent {
+
+	/**
+	 * Instantiates the shallow antecedent.
+	 * @param impliedLiteral the literal that is implied by this {@link ShallowAntecedent}.
+	 * @return a (full) {@link Antecedent}.
+	 */
+	Antecedent instantiateAntecedent(int impliedLiteral);
+
+	@Override
+	default int[] getReasonLiterals() {
+		throw oops("ShallowAntecedent must be instantiated first.");
+	}
+
+	@Override
+	default void bumpActivity() {
+		throw oops("ShallowAntecedent must be instantiated first.");
+	}
+
+	@Override
+	default void decreaseActivity() {
+		throw oops("ShallowAntecedent must be instantiated first.");
+	}
+}

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/TrailAssignment.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/TrailAssignment.java
@@ -29,6 +29,7 @@ package at.ac.tuwien.kr.alpha.solver;
 
 import at.ac.tuwien.kr.alpha.common.Assignment;
 import at.ac.tuwien.kr.alpha.common.AtomStore;
+import at.ac.tuwien.kr.alpha.common.IntIterator;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,11 +46,11 @@ import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.*;
  * An implementation of Assignment using a trail (of literals) and arrays as underlying structures for storing
  * assignments.
  *
- * Copyright (c) 2018-2019, the Alpha Team.
+ * Copyright (c) 2018-2020, the Alpha Team.
  */
 public class TrailAssignment implements WritableAssignment, Checkable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(TrailAssignment.class);
-	public static final Antecedent CLOSING_INDICATOR_ANTECEDENT = new Antecedent() {
+	static final Antecedent CLOSING_INDICATOR_ANTECEDENT = new Antecedent() {
 		int[] literals = new int[0];
 
 		@Override
@@ -83,7 +84,8 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 	private boolean[] callbackUponChange;
 	private ArrayList<OutOfOrderLiteral> outOfOrderLiterals = new ArrayList<>();
 	private int highestDecisionLevelContainingOutOfOrderLiterals;
-	private ArrayList<Integer> trail = new ArrayList<>();
+	private int[] trail = new int[0];
+	private int trailSize;
 	private ArrayList<Integer> trailIndicesOfDecisionLevels = new ArrayList<>();
 
 	private int nextPositionInTrail;
@@ -121,7 +123,8 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 		Arrays.fill(callbackUponChange, false);
 		outOfOrderLiterals = new ArrayList<>();
 		highestDecisionLevelContainingOutOfOrderLiterals = 0;
-		trail = new ArrayList<>();
+		Arrays.fill(trail, 0);
+		trailSize = 0;
 		trailIndicesOfDecisionLevels = new ArrayList<>();
 		trailIndicesOfDecisionLevels.add(0);
 		nextPositionInTrail = 0;
@@ -189,7 +192,7 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 		return lowestDecisionLevel;
 	}
 
-	public int getOutOfOrderStrongDecisionLevel(int atom) {
+	int getOutOfOrderStrongDecisionLevel(int atom) {
 		int lowestDecisionLevel = Integer.MAX_VALUE;
 		for (OutOfOrderLiteral outOfOrderLiteral : outOfOrderLiterals) {
 			if (outOfOrderLiteral.atom == atom && outOfOrderLiteral.value == TRUE && outOfOrderLiteral.decisionLevel < lowestDecisionLevel) {
@@ -199,7 +202,7 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 		return lowestDecisionLevel;
 	}
 
-	private void informCallback(Integer atom) {
+	private void informCallback(int atom) {
 		if (callbackUponChange[atom]) {
 			choiceManagerCallback.callbackOnChanged(atom);
 		}
@@ -208,9 +211,8 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 	private void removeLastDecisionLevel() {
 		// Remove all atoms recorded in the highest decision level.
 		int start = trailIndicesOfDecisionLevels.get(getDecisionLevel());
-		ListIterator<Integer> backtrackIterator = trail.listIterator(start);
-		while (backtrackIterator.hasNext()) {
-			int backtrackAtom = atomOf(backtrackIterator.next());
+		for (int i = start; i < trailSize; i++) {
+			int backtrackAtom = atomOf(trail[i]); //atomOf(backtrackIterator.next());
 			// Skip already backtracked atoms.
 			if (getTruth(backtrackAtom) == null) {
 				continue;
@@ -232,13 +234,8 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 			informCallback(backtrackAtom);
 		}
 		// Remove atoms from trail.
-		while (trail.size() > start) {
-			trail.remove(trail.size() - 1);
-		}
+		trailSize = start;
 		trailIndicesOfDecisionLevels.remove(trailIndicesOfDecisionLevels.size() - 1);
-
-		int trailCurrentIndex = trail.size();
-		int trailPrevIndex = trailIndicesOfDecisionLevels.size() < 1  ? 0 : trailIndicesOfDecisionLevels.get(trailIndicesOfDecisionLevels.size() - 1);
 	}
 
 	private void replayOutOfOrderLiterals() {
@@ -258,7 +255,9 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 				}
 			}
 			replayCounter += outOfOrderLiterals.size();
-			LOGGER.trace("Replay list contained {} literals, {} were again assigned. Overall replays: {}.", outOfOrderLiterals.size(), k, replayCounter);
+			if (LOGGER.isTraceEnabled()) {
+				LOGGER.trace("Replay list contained {} literals, {} were again assigned. Overall replays: {}.", outOfOrderLiterals.size(), k, replayCounter);
+			}
 			// Remove remaining entries from k onwards.
 			while (outOfOrderLiterals.size() > k) {
 				outOfOrderLiterals.remove(outOfOrderLiterals.size() - 1);
@@ -268,10 +267,10 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 	}
 
 	private void resetTrailPointersAndReplayOutOfOrderLiterals() {
-		nextPositionInTrail = Math.min(nextPositionInTrail, trail.size());
-		newAssignmentsPositionInTrail = Math.min(newAssignmentsPositionInTrail, trail.size());
-		newAssignmentsIterator = Math.min(newAssignmentsIterator, trail.size());
-		assignmentsForChoicePosition = Math.min(assignmentsForChoicePosition, trail.size());
+		nextPositionInTrail = Math.min(nextPositionInTrail, trailSize);
+		newAssignmentsPositionInTrail = Math.min(newAssignmentsPositionInTrail, trailSize);
+		newAssignmentsIterator = Math.min(newAssignmentsIterator, trailSize);
+		assignmentsForChoicePosition = Math.min(assignmentsForChoicePosition, trailSize);
 		replayOutOfOrderLiterals();
 		if (checksEnabled) {
 			runInternalChecks();
@@ -303,14 +302,14 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 		if (checksEnabled) {
 			runInternalChecks();
 		}
-		trailIndicesOfDecisionLevels.add(trail.size());
+		trailIndicesOfDecisionLevels.add(trailSize);
 		return assign(atom, value, null);
 	}
 
 	@Override
 	public ConflictCause assign(int atom, ThriceTruth value, Antecedent impliedBy) {
 		ConflictCause conflictCause = assignWithTrail(atom, value, impliedBy);
-		if (conflictCause != null) {
+		if (conflictCause != null && LOGGER.isDebugEnabled()) {
 			LOGGER.debug("Assign is conflicting: atom: {}, value: {}, impliedBy: {}.", atom, value, impliedBy);
 		}
 		return conflictCause;
@@ -350,7 +349,7 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 		// If the atom currently is not assigned, simply record the assignment.
 		final ThriceTruth currentTruth = getTruth(atom);
 		if (currentTruth == null) {
-			trail.add(atomToLiteral(atom, value.toBoolean()));
+			trail[trailSize++] = atomToLiteral(atom, value.toBoolean());
 			values[atom] = (getDecisionLevel() << 2) | translateTruth(value);
 			this.impliedBy[atom] = impliedBy;
 			// Adjust MBT counter.
@@ -373,6 +372,10 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 		if (!assignmentsConsistent(currentTruth, value)) {
 			// Assignments are inconsistent, prepare the reason.
 			// Due to the conflict, the impliedBy NoGood is not the recorded one but the one this method is invoked with.stems from this assignment.
+			if (impliedBy instanceof ShallowAntecedent) {
+				// Instantiate Antecedent in case it is a shallow one for binary nogoods.
+				return new ConflictCause(((ShallowAntecedent) impliedBy).instantiateAntecedent(atomToLiteral(atom, !value.toBoolean())));
+			}
 			return new ConflictCause(impliedBy);
 		}
 		if (value == TRUE && currentTruth != MBT) {
@@ -383,7 +386,7 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 		// There is nothing to do except if MBT becomes TRUE.
 		if (currentTruth == MBT && value == TRUE) {
 			// Record new truth value but keep weak decision level unchanged.
-			trail.add(atomToLiteral(atom, true));
+			trail[trailSize++] = atomToLiteral(atom, true);
 			values[atom] = (getWeakDecisionLevel(atom) << 2) | translateTruth(TRUE);
 			// Record strong decision level.
 			strongDecisionLevels[atom] = getDecisionLevel();
@@ -442,7 +445,12 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 
 	@Override
 	public Antecedent getImpliedBy(int atom) {
-		return impliedBy[atom];
+		Antecedent antecedent = impliedBy[atom];
+		// Check if the Antecedent is a shallow one from binary nogoods, in this case instantiate it to a full Antecedent.
+		if (antecedent instanceof ShallowAntecedent) {
+			return ((ShallowAntecedent) antecedent).instantiateAntecedent(atomToLiteral(atom, !getTruth(atom).toBoolean()));
+		}
+		return antecedent;
 	}
 
 	@Override
@@ -534,6 +542,7 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 		Arrays.fill(strongDecisionLevels, oldLength, strongDecisionLevels.length, -1);
 		impliedBy = Arrays.copyOf(impliedBy, newCapacity);
 		callbackUponChange = Arrays.copyOf(callbackUponChange, newCapacity);
+		trail = Arrays.copyOf(trail, newCapacity * 2);	// Trail has at most 2 assignments (MBT+TRUE) for each atom.
 	}
 
 	public int getNumberOfAssignedAtoms() {
@@ -550,8 +559,8 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 	public int getNumberOfAtomsAssignedSinceLastDecision() {
 		Set<Integer> newlyAssignedAtoms = new HashSet<>();
 		int trailIndex = trailIndicesOfDecisionLevels.get(getDecisionLevel());
-		for (; trailIndex < trail.size(); trailIndex++) {
-			newlyAssignedAtoms.add(atomOf(trail.get(trailIndex)));
+		for (; trailIndex < trailSize; trailIndex++) {
+			newlyAssignedAtoms.add(atomOf(trail[trailIndex]));
 		}
 		return newlyAssignedAtoms.size();
 	}
@@ -598,11 +607,11 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 		this.checksEnabled = checksEnabled;
 	}
 
-	private class AssignmentIterator implements Iterator<Integer> {
+	private class AssignmentIterator implements IntIterator {
 
 		private void advanceCursorToNextPositiveAssignment() {
-			while (newAssignmentsIterator < trail.size()) {
-				ThriceTruth truth = getTruth(atomOf(trail.get(newAssignmentsIterator)));
+			while (newAssignmentsIterator < trailSize) {
+				ThriceTruth truth = getTruth(atomOf(trail[newAssignmentsIterator]));
 				if (truth != null && truth.toBoolean()) {
 					return;
 				}
@@ -610,15 +619,13 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 			}
 		}
 
-		@Override
 		public boolean hasNext() {
 			advanceCursorToNextPositiveAssignment();
-			return newAssignmentsIterator < trail.size();
+			return newAssignmentsIterator < trailSize;
 		}
 
-		@Override
-		public Integer next() {
-			return atomOf(trail.get(newAssignmentsIterator++));
+		public int next() {
+			return atomOf(trail[newAssignmentsIterator++]);
 
 		}
 	}
@@ -646,7 +653,7 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 
 		@Override
 		public int peek() {
-			return atomOf(trail.get(nextPositionInTrail));
+			return atomOf(trail[nextPositionInTrail]);
 		}
 
 		@Override
@@ -658,7 +665,7 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 
 		@Override
 		public boolean isEmpty() {
-			return nextPositionInTrail >= trail.size();
+			return nextPositionInTrail >= trailSize;
 		}
 	}
 
@@ -671,17 +678,18 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 		int trailPos;
 
 		TrailBackwardsWalker() {
-			trailPos = trail.size();
+			trailPos = trailSize;
 		}
 
 		public int getNextLowerLiteral() {
-			return trail.get(--trailPos);
+			return trail[--trailPos];
 		}
 
 		@Override
 		public String toString() {
 			StringBuilder sb = new StringBuilder("[");
-			for (Integer literalOnTrail : trail) {
+			for (int i = 0; i < trailSize; i++) {
+				int literalOnTrail = trail[i];
 				sb.append(isPositive(literalOnTrail) ? "+" + atomOf(literalOnTrail) : "-" + atomOf(literalOnTrail));
 				sb.append("@");
 				sb.append(TrailAssignment.this.getWeakDecisionLevel(atomOf(literalOnTrail)));

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/heuristics/HeapOfActiveAtoms.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/heuristics/HeapOfActiveAtoms.java
@@ -217,7 +217,9 @@ public class HeapOfActiveAtoms {
 
 	private void setActivity(int atom, double newActivity) {
 		activityScores[atom] = newActivity;
-		LOGGER.trace("Activity of atom {} set to {}", atom, newActivity);
+		if (LOGGER.isTraceEnabled()) {
+			LOGGER.trace("Activity of atom {} set to {}", atom, newActivity);
+		}
 
 		if (newActivity > NORMALIZATION_THRESHOLD) {
 			normalizeActivityScores();

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/learning/GroundConflictNoGoodLearner.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/learning/GroundConflictNoGoodLearner.java
@@ -45,7 +45,8 @@ import static at.ac.tuwien.kr.alpha.solver.NoGoodStore.LBD_NO_VALUE;
 
 /**
  * Conflict-driven learning on ground clauses.
- * Copyright (c) 2016-2019, the Alpha Team.
+ *
+ * Copyright (c) 2016-2020, the Alpha Team.
  */
 public class GroundConflictNoGoodLearner {
 	private static final Logger LOGGER = LoggerFactory.getLogger(GroundConflictNoGoodLearner.class);
@@ -247,7 +248,9 @@ public class GroundConflictNoGoodLearner {
 				return ConflictAnalysisResult.UNSAT;
 			}
 		}
-		LOGGER.trace("Backjumping decision level: {}", backjumpingDecisionLevel);
+		if (LOGGER.isTraceEnabled()) {
+			LOGGER.trace("Backjumping decision level: {}", backjumpingDecisionLevel);
+		}
 		return new ConflictAnalysisResult(learnedNoGood, backjumpingDecisionLevel, resolutionAtoms, computeLBD(learnedLiterals));
 	}
 

--- a/src/test/java/at/ac/tuwien/kr/alpha/grounder/ChoiceGrounder.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/grounder/ChoiceGrounder.java
@@ -171,7 +171,7 @@ public class ChoiceGrounder implements Grounder {
 	}
 
 	@Override
-	public void updateAssignment(Iterator<Integer> it) {
+	public void updateAssignment(IntIterator it) {
 		// This test grounder reports all NoGoods immediately, irrespective of any assignment.
 	}
 

--- a/src/test/java/at/ac/tuwien/kr/alpha/grounder/DummyGrounder.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/grounder/DummyGrounder.java
@@ -156,7 +156,7 @@ public class DummyGrounder implements Grounder {
 	}
 
 	@Override
-	public void updateAssignment(Iterator<Integer> it) {
+	public void updateAssignment(IntIterator it) {
 		while (it.hasNext()) {
 			currentTruthValues[it.next()] = 1;
 		}

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/TrailAssignmentTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/TrailAssignmentTest.java
@@ -31,19 +31,24 @@ import at.ac.tuwien.kr.alpha.common.Assignment;
 import at.ac.tuwien.kr.alpha.common.AtomStore;
 import at.ac.tuwien.kr.alpha.common.AtomStoreImpl;
 import at.ac.tuwien.kr.alpha.common.AtomStoreTest;
+import at.ac.tuwien.kr.alpha.common.IntIterator;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 
-import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.*;
-import static org.junit.Assert.*;
+import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.FALSE;
+import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.MBT;
+import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.TRUE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
- * Copyright (c) 2018, the Alpha Team.
+ * Copyright (c) 2018-2020, the Alpha Team.
  */
 public class TrailAssignmentTest {
 	private final TrailAssignment assignment;
@@ -163,7 +168,7 @@ public class TrailAssignmentTest {
 
 	@Test
 	public void newAssignmentsIteratorAndBacktracking() throws Exception {
-		Iterator<Integer> newAssignmentsIterator;
+		IntIterator newAssignmentsIterator;
 
 		assignment.assign(1, MBT);
 		assignment.choose(2, MBT);
@@ -186,7 +191,7 @@ public class TrailAssignmentTest {
 
 	@Test
 	public void newAssignmentsIteratorLowerDecisionLevelAndBacktracking() throws Exception {
-		Iterator<Integer> newAssignmentsIterator;
+		IntIterator newAssignmentsIterator;
 
 		assignment.choose(1, MBT);
 		assignment.choose(2, MBT);
@@ -248,5 +253,8 @@ public class TrailAssignmentTest {
 		assignment.choose(1, TRUE);
 		assertEquals(3, assignment.getNumberOfAssignedAtoms());
 		assertEquals(1, assignment.getNumberOfAtomsAssignedSinceLastDecision());
+		assignment.assign(5, MBT);
+		assignment.assign(5, TRUE);
+		assertEquals(2, assignment.getNumberOfAtomsAssignedSinceLastDecision());
 	}
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/solver/heuristics/AlphaHeuristicTestAssumptions.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/solver/heuristics/AlphaHeuristicTestAssumptions.java
@@ -96,6 +96,7 @@ public class AlphaHeuristicTestAssumptions {
 
 		Collection<NoGood> noGoods = getNoGoods();
 		assignment.growForMaxAtomId();
+		choiceManager.growForMaxAtomId(atomStore.getMaxAtomId());
 		choiceManager.addChoiceInformation(grounder.getChoiceAtoms(), grounder.getHeadsToBodies());
 		for (NoGood noGood : noGoods) {
 			n++;
@@ -141,6 +142,7 @@ public class AlphaHeuristicTestAssumptions {
 	private void testIsAtomChoice(Predicate<? super Integer> isRuleBody) {
 		Collection<NoGood> noGoods = getNoGoods();
 		assignment.growForMaxAtomId();
+		choiceManager.growForMaxAtomId(atomStore.getMaxAtomId());
 		choiceManager.addChoiceInformation(grounder.getChoiceAtoms(), grounder.getHeadsToBodies());
 		for (NoGood noGood : noGoods) {
 			for (Integer literal : noGood) {


### PR DESCRIPTION
Alpha currently creates a lot of temporary `Integer` objects, most of it by autoboxing. This PR significantly reduces the amount of those (on some instance from 144 million down to 4 million temporary `Integer` objects).

The changes are as follows:

- Introduction of `IntIterator` instead of `Iterator<Integer>`.
- `TrailAssignment` stores the trail as `int[]` instead of `ArrayList<Integer>`.
- Logger calls that print `int` (which get autoboxed to `Integer`) moved inside corresponding if-statements.
- Additionally avoid creation of never-needed `BinaryAntecedent` by lazily postponing their instantiation, using a long-living object as placeholder (i.e., `ShallowAntecedent`).