### PR TITLE
Bugfix: String-typed ConstantTerms for strings and constant symbols mistakenly equal (Issue #244)

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/common/terms/ConstantTerm.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/terms/ConstantTerm.java
@@ -120,7 +120,7 @@ public class ConstantTerm<T extends Comparable<T>> extends Term {
 		// wrong if we have some bug that generates strange
 		// ConstantTerms at runtime, bypassing the check for T
 		// at compile-time.
-		if (other.object.getClass() == this.object.getClass()) {
+		if (other.object.getClass() == this.object.getClass() && other.symbolic == this.symbolic) {
 			return this.object.compareTo((T) other.object);
 		}
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/terms/ConstantTerm.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/terms/ConstantTerm.java
@@ -7,7 +7,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Copyright (c) 2016, the Alpha Team.
+ * Copyright (c) 2016-2020, the Alpha Team.
  */
 public class ConstantTerm<T extends Comparable<T>> extends Term {
 	private static final Interner<ConstantTerm> INTERNER = new Interner<>();

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/terms/ConstantTerm.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/terms/ConstantTerm.java
@@ -67,7 +67,10 @@ public class ConstantTerm<T extends Comparable<T>> extends Term {
 			return false;
 		}
 
-		ConstantTerm that = (ConstantTerm) o;
+		ConstantTerm<?> that = (ConstantTerm<?>) o;
+		if (this.symbolic != that.symbolic) {
+			return false;
+		}
 
 		return object.equals(that.object);
 	}
@@ -103,7 +106,7 @@ public class ConstantTerm<T extends Comparable<T>> extends Term {
 			return super.compareTo(o);
 		}
 
-		ConstantTerm other = (ConstantTerm) o;
+		ConstantTerm<?> other = (ConstantTerm<?>) o;
 
 		// We will perform an unchecked cast.
 		// Because of type erasure, we cannot know the exact type

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/TermTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/TermTest.java
@@ -4,6 +4,8 @@ import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.FunctionTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;
 import at.ac.tuwien.kr.alpha.common.terms.VariableTerm;
+
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.LinkedList;
@@ -20,7 +22,8 @@ public class TermTest {
 
 	@Test
 	public void testTermReferenceEquality() {
-		// Terms must have a unique representation so that reference comparison is sufficient to check
+		// Terms must have a unique representation so that reference comparison is
+		// sufficient to check
 		// whether two terms are equal.
 		ConstantTerm ta1 = ConstantTerm.getInstance("a");
 		ConstantTerm ta2 = ConstantTerm.getInstance("a");
@@ -65,5 +68,12 @@ public class TermTest {
 
 		assertTrue(cto.compareTo(ft) < 0);
 		assertTrue(ft.compareTo(cto) > 0);
+	}
+
+	@Test
+	public void testStringTermEquality() {
+		ConstantTerm<String> stringConstant = ConstantTerm.getInstance("string");
+		ConstantTerm<String> constantSymbol = ConstantTerm.getSymbolicInstance("string");
+		Assert.assertNotEquals(stringConstant, constantSymbol);
 	}
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/TermTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/TermTest.java
@@ -71,9 +71,19 @@ public class TermTest {
 	}
 
 	@Test
-	public void testStringTermEquality() {
+	public void testStringVsConstantSymbolEquality() {
 		ConstantTerm<String> stringConstant = ConstantTerm.getInstance("string");
 		ConstantTerm<String> constantSymbol = ConstantTerm.getSymbolicInstance("string");
+		System.out.println(stringConstant.hashCode());
+		System.out.println(constantSymbol.hashCode());
+		// reference equality must hold for both constructs..
+		Assert.assertTrue(stringConstant == ConstantTerm.getInstance("string"));
+		ConstantTerm<String> sameConstantSymbol = ConstantTerm.getSymbolicInstance("string");
+		Assert.assertTrue(constantSymbol == sameConstantSymbol);
+		// ... but stringConstant and constantSymbol are NOT the same thing!
+		Assert.assertNotEquals(stringConstant.hashCode(), constantSymbol.hashCode());
 		Assert.assertNotEquals(stringConstant, constantSymbol);
+		// ... same goes for compareTo, must behave in sync with equals and hashCode
+		Assert.assertNotEquals(0, stringConstant.compareTo(constantSymbol));
 	}
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/TermTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/TermTest.java
@@ -72,16 +72,20 @@ public class TermTest {
 
 	@Test
 	public void testStringVsConstantSymbolEquality() {
-		ConstantTerm<String> stringConstant = ConstantTerm.getInstance("string");
-		ConstantTerm<String> constantSymbol = ConstantTerm.getSymbolicInstance("string");
-		// reference equality must hold for both constructs..
-		Assert.assertTrue(stringConstant == ConstantTerm.getInstance("string"));
-		ConstantTerm<String> sameConstantSymbol = ConstantTerm.getSymbolicInstance("string");
+		String theString = "string";
+		ConstantTerm<String> stringConstant = ConstantTerm.getInstance(theString);
+		ConstantTerm<String> constantSymbol = ConstantTerm.getSymbolicInstance(theString);
+		// Reference equality must hold for both the string constant and the constant
+		// symbol.
+		Assert.assertTrue(stringConstant == ConstantTerm.getInstance(theString));
+		ConstantTerm<String> sameConstantSymbol = ConstantTerm.getSymbolicInstance(theString);
 		Assert.assertTrue(constantSymbol == sameConstantSymbol);
-		// ... but stringConstant and constantSymbol are NOT the same thing!
+		// Make sure both hashCode and equals understand that stringConstant and
+		// constantSymbol are NOT the same thing!
 		Assert.assertNotEquals(stringConstant.hashCode(), constantSymbol.hashCode());
 		Assert.assertNotEquals(stringConstant, constantSymbol);
-		// ... same goes for compareTo, must behave in sync with equals and hashCode
+		// This also applies to compareTo - it must behave in sync with equals and
+		// hashCode, i.e. return a non-zero result for non-equal objects
 		Assert.assertNotEquals(0, stringConstant.compareTo(constantSymbol));
 	}
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/TermTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/TermTest.java
@@ -74,8 +74,6 @@ public class TermTest {
 	public void testStringVsConstantSymbolEquality() {
 		ConstantTerm<String> stringConstant = ConstantTerm.getInstance("string");
 		ConstantTerm<String> constantSymbol = ConstantTerm.getSymbolicInstance("string");
-		System.out.println(stringConstant.hashCode());
-		System.out.println(constantSymbol.hashCode());
 		// reference equality must hold for both constructs..
 		Assert.assertTrue(stringConstant == ConstantTerm.getInstance("string"));
 		ConstantTerm<String> sameConstantSymbol = ConstantTerm.getSymbolicInstance("string");


### PR DESCRIPTION
Fixes the bug described in issue #244
* Extended `ConstantTerm#equals` to check whether `this.symbolic != other.symbolic`
* Extended `ConstantTerm#compareTo` to compare based on priority if `this.symbolic != other.symbolic`
* additional Test Case in `TermTest` checking the condition from issue #244 