### PR TITLE
Move substitution test

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
@@ -704,31 +704,6 @@ public class NaiveGrounder extends BridgedGrounder implements ProgramAnalyzingGr
 		throw new UnsupportedOperationException("Forgetting assignments is not implemented");
 	}
 
-	public static String groundAndPrintRule(NonGroundRule rule, Substitution substitution) {
-		StringBuilder ret = new StringBuilder();
-		if (!rule.isConstraint()) {
-			Atom groundHead = rule.getHeadAtom().substitute(substitution);
-			ret.append(groundHead.toString());
-		}
-		ret.append(" :- ");
-		boolean isFirst = true;
-		for (Atom bodyAtom : rule.getBodyAtomsPositive()) {
-			ret.append(groundLiteralToString(bodyAtom.toLiteral(), substitution, isFirst));
-			isFirst = false;
-		}
-		for (Atom bodyAtom : rule.getBodyAtomsNegative()) {
-			ret.append(groundLiteralToString(bodyAtom.toLiteral(false), substitution, isFirst));
-			isFirst = false;
-		}
-		ret.append(".");
-		return ret.toString();
-	}
-
-	static String groundLiteralToString(Literal literal, Substitution substitution, boolean isFirst) {
-		Literal groundLiteral = literal.substitute(substitution);
-		return  (isFirst ? "" : ", ") + groundLiteral.toString();
-	}
-
 	@Override
 	public NonGroundRule getNonGroundRule(Integer ruleId) {
 		return knownNonGroundRules.get(ruleId);

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/SubstitutionTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/SubstitutionTest.java
@@ -29,6 +29,7 @@ package at.ac.tuwien.kr.alpha.grounder;
 
 import at.ac.tuwien.kr.alpha.common.Predicate;
 import at.ac.tuwien.kr.alpha.common.Rule;
+import at.ac.tuwien.kr.alpha.common.SubstitutionTestUtil;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicLiteral;
 import at.ac.tuwien.kr.alpha.common.atoms.Literal;
@@ -96,7 +97,7 @@ public class SubstitutionTest {
 		Substitution substitution = new Substitution();
 		substitution.unifyTerms(X, A);
 		substitution.unifyTerms(Y, B);
-		String printedString = NaiveGrounder.groundAndPrintRule(nonGroundRule, substitution);
+		String printedString = SubstitutionTestUtil.groundAndPrintRule(nonGroundRule, substitution);
 		assertEquals("x :- p(a, b), not q(a, b).", printedString);
 	}
 
@@ -130,7 +131,7 @@ public class SubstitutionTest {
 		Substitution substitution = new Substitution();
 		substitution.unifyTerms(X, A);
 		substitution.unifyTerms(Y, B);
-		String printedString = NaiveGrounder.groundLiteralToString(atom.toLiteral(!negated), substitution, true);
+		String printedString = SubstitutionTestUtil.groundLiteralToString(atom.toLiteral(!negated), substitution, true);
 		assertEquals((negated ? "not " : "") + "p(a, b)", printedString);
 	}
 

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/SubstitutionTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/SubstitutionTest.java
@@ -1,19 +1,19 @@
-/**
+/*
  * Copyright (c) 2016-2018, the Alpha Team.
  * All rights reserved.
- * 
+ *
  * Additional changes made by Siemens.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1) Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
- * 
+ *
  * 2) Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,11 +25,8 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package at.ac.tuwien.kr.alpha.grounder;
+package at.ac.tuwien.kr.alpha.common;
 
-import at.ac.tuwien.kr.alpha.common.Predicate;
-import at.ac.tuwien.kr.alpha.common.Rule;
-import at.ac.tuwien.kr.alpha.common.SubstitutionTestUtil;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicLiteral;
 import at.ac.tuwien.kr.alpha.common.atoms.Literal;
@@ -37,6 +34,8 @@ import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.FunctionTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;
 import at.ac.tuwien.kr.alpha.common.terms.VariableTerm;
+import at.ac.tuwien.kr.alpha.grounder.NonGroundRule;
+import at.ac.tuwien.kr.alpha.grounder.Substitution;
 import at.ac.tuwien.kr.alpha.grounder.atoms.RuleAtom;
 import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
 import org.junit.Test;
@@ -46,9 +45,6 @@ import java.util.Arrays;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-/**
- * Copyright (c) 2016-2018, the Alpha Team.
- */
 public class SubstitutionTest {
 	static final ProgramParser PARSER = new ProgramParser();
 

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/SubstitutionTestUtil.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/SubstitutionTestUtil.java
@@ -1,4 +1,62 @@
+/**
+ * Copyright (c) 2016-2020, the Alpha Team.
+ * All rights reserved.
+ *
+ * Additional changes made by Siemens.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package at.ac.tuwien.kr.alpha.common;
 
+import at.ac.tuwien.kr.alpha.common.atoms.Atom;
+import at.ac.tuwien.kr.alpha.common.atoms.Literal;
+import at.ac.tuwien.kr.alpha.grounder.NonGroundRule;
+import at.ac.tuwien.kr.alpha.grounder.Substitution;
+
 public class SubstitutionTestUtil {
+
+	static String groundAndPrintRule(NonGroundRule rule, Substitution substitution) {
+		StringBuilder ret = new StringBuilder();
+		if (!rule.isConstraint()) {
+			Atom groundHead = rule.getHeadAtom().substitute(substitution);
+			ret.append(groundHead.toString());
+		}
+		ret.append(" :- ");
+		boolean isFirst = true;
+		for (Atom bodyAtom : rule.getBodyAtomsPositive()) {
+			ret.append(groundLiteralToString(bodyAtom.toLiteral(), substitution, isFirst));
+			isFirst = false;
+		}
+		for (Atom bodyAtom : rule.getBodyAtomsNegative()) {
+			ret.append(groundLiteralToString(bodyAtom.toLiteral(false), substitution, isFirst));
+			isFirst = false;
+		}
+		ret.append(".");
+		return ret.toString();
+	}
+
+	static String groundLiteralToString(Literal literal, Substitution substitution, boolean isFirst) {
+		Literal groundLiteral = literal.substitute(substitution);
+		return  (isFirst ? "" : ", ") + groundLiteral.toString();
+	}
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/SubstitutionTestUtil.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/SubstitutionTestUtil.java
@@ -1,0 +1,4 @@
+package at.ac.tuwien.kr.alpha.common;
+
+public class SubstitutionTestUtil {
+}

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/UnifierTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/UnifierTest.java
@@ -1,9 +1,33 @@
-package at.ac.tuwien.kr.alpha.grounder;
+/*
+ * Copyright (c) 2018, 2020, the Alpha Team.
+ * All rights reserved.
+ *
+ * Additional changes made by Siemens.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
-import at.ac.tuwien.kr.alpha.common.Predicate;
-import at.ac.tuwien.kr.alpha.common.Program;
-import at.ac.tuwien.kr.alpha.common.Rule;
-import at.ac.tuwien.kr.alpha.common.SubstitutionTestUtil;
+package at.ac.tuwien.kr.alpha.common;
+
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicLiteral;
@@ -12,6 +36,9 @@ import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.FunctionTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;
 import at.ac.tuwien.kr.alpha.common.terms.VariableTerm;
+import at.ac.tuwien.kr.alpha.grounder.NonGroundRule;
+import at.ac.tuwien.kr.alpha.grounder.Substitution;
+import at.ac.tuwien.kr.alpha.grounder.Unifier;
 import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
 import org.junit.Test;
 
@@ -19,9 +46,6 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 
-/**
- * Copyright (c) 2018, the Alpha Team.
- */
 public class UnifierTest extends SubstitutionTest {
 
 	@Test

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/UnifierTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/UnifierTest.java
@@ -3,6 +3,7 @@ package at.ac.tuwien.kr.alpha.grounder;
 import at.ac.tuwien.kr.alpha.common.Predicate;
 import at.ac.tuwien.kr.alpha.common.Program;
 import at.ac.tuwien.kr.alpha.common.Rule;
+import at.ac.tuwien.kr.alpha.common.SubstitutionTestUtil;
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicLiteral;
@@ -99,7 +100,7 @@ public class UnifierTest extends SubstitutionTest {
 		Substitution substitution = new Unifier();
 		substitution.unifyTerms(X, A);
 		substitution.unifyTerms(Y, B);
-		String printedString = NaiveGrounder.groundAndPrintRule(nonGroundRule, substitution);
+		String printedString = SubstitutionTestUtil.groundAndPrintRule(nonGroundRule, substitution);
 		assertEquals("x :- p(a, b), not q(a, b).", printedString);
 	}
 
@@ -133,7 +134,7 @@ public class UnifierTest extends SubstitutionTest {
 		Substitution substitution = new Unifier();
 		substitution.unifyTerms(X, A);
 		substitution.unifyTerms(Y, B);
-		String printedString = NaiveGrounder.groundLiteralToString(atom.toLiteral(!negated), substitution, true);
+		String printedString = SubstitutionTestUtil.groundLiteralToString(atom.toLiteral(!negated), substitution, true);
 		assertEquals((negated ? "not " : "") + "p(a, b)", printedString);
 	}
 }


### PR DESCRIPTION
Move `SubstitutionTest` and `UnifierTest` to `common` package because `Substitution` and `Unifier` are also in `common` package. Move also two static methods from `NaiveGrounder` to a new class `SubstitutionTestUtil` because those methods are only used by tests.