### PR TITLE
Introduce ProgramPartParser to simplify construction of parts of programs

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/Substitution.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/Substitution.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2019, the Alpha Team.
+/*
+ * Copyright (c) 2016-2020, the Alpha Team.
  * All rights reserved.
  *
  * Additional changes made by Siemens.
@@ -27,21 +27,14 @@
  */
 package at.ac.tuwien.kr.alpha.grounder;
 
-import at.ac.tuwien.kr.alpha.antlr.ASPCore2Lexer;
-import at.ac.tuwien.kr.alpha.antlr.ASPCore2Parser;
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
 import at.ac.tuwien.kr.alpha.common.atoms.Literal;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.FunctionTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;
 import at.ac.tuwien.kr.alpha.common.terms.VariableTerm;
-import at.ac.tuwien.kr.alpha.grounder.parser.ParseTreeVisitor;
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.RecognitionException;
-import org.antlr.v4.runtime.misc.ParseCancellationException;
+import at.ac.tuwien.kr.alpha.grounder.parser.ProgramPartParser;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
@@ -49,7 +42,8 @@ import java.util.TreeMap;
 import static at.ac.tuwien.kr.alpha.Util.oops;
 
 public class Substitution {
-	private static final ParseTreeVisitor VISITOR = new ParseTreeVisitor(Collections.emptyMap(), false);
+
+	private static final ProgramPartParser PROGRAM_PART_PARSER = new ProgramPartParser();
 
 	protected TreeMap<VariableTerm, Term> substitution;
 
@@ -198,22 +192,10 @@ public class Substitution {
 		for (String assignment : assignments) {
 			String keyVal[] = assignment.split("->");
 			VariableTerm variable = VariableTerm.getInstance(keyVal[0]);
-			Term assignedTerm = parseTerm(keyVal[1]);
+			Term assignedTerm = PROGRAM_PART_PARSER.parseTerm(keyVal[1]);
 			ret.put(variable, assignedTerm);
 		}
 		return ret;
-	}
-
-	private static Term parseTerm(String s) {
-		try {
-			final ASPCore2Parser parser = new ASPCore2Parser(new CommonTokenStream(new ASPCore2Lexer(CharStreams.fromString(s))));
-			return (Term)VISITOR.visit(parser.term());
-		} catch (RecognitionException | ParseCancellationException e) {
-			// If there were issues parsing the given string, we
-			// throw something that suggests that the input string
-			// is malformed.
-			throw new IllegalArgumentException("Could not parse term.", e);
-		}
 	}
 
 	@Override

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ProgramPartParser.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ProgramPartParser.java
@@ -46,7 +46,7 @@ import java.util.Collections;
  * atoms, terms and such.
  */
 public class ProgramPartParser {
-	private final ParseTreeVisitor visitor = new ParseTreeVisitor(Collections.emptyMap(), false);
+	private final ParseTreeVisitor visitor = new ParseTreeVisitor(Collections.emptyMap(), true);
 
 	public Term parseTerm(String s) {
 		final ASPCore2Parser parser = getASPCore2Parser(s);

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ProgramPartParser.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ProgramPartParser.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018-2020, the Alpha Team.
+ * All rights reserved.
+ *
+ * Additional changes made by Siemens.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package at.ac.tuwien.kr.alpha.grounder.parser;
+
+import at.ac.tuwien.kr.alpha.antlr.ASPCore2Lexer;
+import at.ac.tuwien.kr.alpha.antlr.ASPCore2Parser;
+import at.ac.tuwien.kr.alpha.common.terms.Term;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+
+import java.util.Collections;
+
+/**
+ * A parser that, in contrast to {@link ProgramParser}, does not parse full programs but only program parts like
+ * atoms, terms and such.
+ */
+public class ProgramPartParser {
+	private final ParseTreeVisitor visitor = new ParseTreeVisitor(Collections.emptyMap(), false);
+
+	public Term parseTerm(String s) {
+		final ASPCore2Parser parser = new ASPCore2Parser(new CommonTokenStream(new ASPCore2Lexer(CharStreams.fromString(s))));
+		return (Term)parse(parser.term());
+	}
+
+	private Object parse(ParserRuleContext context) {
+		try {
+			return visitor.visit(context);
+		} catch (RecognitionException | ParseCancellationException e) {
+			// If there were issues parsing the given string, we
+			// throw something that suggests that the input string
+			// is malformed.
+			throw new IllegalArgumentException("Could not parse term.", e);
+		}
+	}
+}

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ProgramPartParser.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/parser/ProgramPartParser.java
@@ -30,6 +30,8 @@ package at.ac.tuwien.kr.alpha.grounder.parser;
 
 import at.ac.tuwien.kr.alpha.antlr.ASPCore2Lexer;
 import at.ac.tuwien.kr.alpha.antlr.ASPCore2Parser;
+import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
+import at.ac.tuwien.kr.alpha.common.atoms.Literal;
 import at.ac.tuwien.kr.alpha.common.terms.Term;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -47,8 +49,22 @@ public class ProgramPartParser {
 	private final ParseTreeVisitor visitor = new ParseTreeVisitor(Collections.emptyMap(), false);
 
 	public Term parseTerm(String s) {
-		final ASPCore2Parser parser = new ASPCore2Parser(new CommonTokenStream(new ASPCore2Lexer(CharStreams.fromString(s))));
+		final ASPCore2Parser parser = getASPCore2Parser(s);
 		return (Term)parse(parser.term());
+	}
+
+	public BasicAtom parseBasicAtom(String s) {
+		final ASPCore2Parser parser = getASPCore2Parser(s);
+		return (BasicAtom)parse(parser.classical_literal());
+	}
+
+	public Literal parseLiteral(String s) {
+		final ASPCore2Parser parser = getASPCore2Parser(s);
+		return (Literal)parse(parser.naf_literal());
+	}
+
+	private ASPCore2Parser getASPCore2Parser(String s) {
+		return new ASPCore2Parser(new CommonTokenStream(new ASPCore2Lexer(CharStreams.fromString(s))));
 	}
 
 	private Object parse(ParserRuleContext context) {

--- a/src/test/java/at/ac/tuwien/kr/alpha/TestUtil.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/TestUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2019 Siemens AG
+/*
+ * Copyright (c) 2019-2020 Siemens AG
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -30,7 +30,6 @@ import at.ac.tuwien.kr.alpha.common.NoGood;
 import at.ac.tuwien.kr.alpha.common.Predicate;
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
-import at.ac.tuwien.kr.alpha.common.atoms.Literal;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;
 import at.ac.tuwien.kr.alpha.common.terms.VariableTerm;
@@ -64,14 +63,6 @@ public class TestUtil {
 			terms[i] = ConstantTerm.getInstance(termInts[i]);
 		}
 		return new BasicAtom(Predicate.getInstance(predicateName, terms.length), terms);
-	}
-
-	public static Literal literal(String predicateName, String... termStrings) {
-		return atom(predicateName, termStrings).toLiteral();
-	}
-
-	public static Literal literal(String predicateName, int... termInts) {
-		return atom(predicateName, termInts).toLiteral();
 	}
 	
 	public static void printNoGoods(AtomStore atomStore, Collection<NoGood> noGoods) {

--- a/src/test/java/at/ac/tuwien/kr/alpha/grounder/RuleGroundingOrderTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/grounder/RuleGroundingOrderTest.java
@@ -137,8 +137,7 @@ public class RuleGroundingOrderTest {
 
 	private RuleGroundingOrders computeGroundingOrdersForRule(Program program, int ruleIndex) {
 		Rule rule = program.getRules().get(ruleIndex);
-		final NonGroundRule nonGroundRule1 = NonGroundRule.constructNonGroundRule(rule);
-		NonGroundRule nonGroundRule = nonGroundRule1;
+		final NonGroundRule nonGroundRule = NonGroundRule.constructNonGroundRule(rule);
 		RuleGroundingOrders rgo = new RuleGroundingOrders(nonGroundRule);
 		rgo.computeGroundingOrders();
 		return rgo;


### PR DESCRIPTION
Some unit tests already have been adapted to use the new parser for `Literal`s instead of using various constructors, which makes the unit tests easier to understand.