### PR TITLE
Fix issue #239

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/TrailAssignment.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/TrailAssignment.java
@@ -317,13 +317,14 @@ public class TrailAssignment implements WritableAssignment, Checkable {
 
 	@Override
 	public ConflictCause assign(int atom, ThriceTruth value, Antecedent impliedBy, int decisionLevel) {
-		if (decisionLevel < getDecisionLevel()) {
+		ConflictCause conflictCause = assign(atom, value, impliedBy);
+		if (conflictCause == null && decisionLevel < getDecisionLevel()) {
 			outOfOrderLiterals.add(new OutOfOrderLiteral(atom, value, decisionLevel, impliedBy));
 			if (highestDecisionLevelContainingOutOfOrderLiterals < getDecisionLevel()) {
 				highestDecisionLevelContainingOutOfOrderLiterals = getDecisionLevel();
 			}
 		}
-		return assign(atom, value, impliedBy);
+		return conflictCause;
 	}
 
 	private boolean assignmentsConsistent(ThriceTruth oldTruth, ThriceTruth value) {

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/learning/GroundConflictNoGoodLearner.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/learning/GroundConflictNoGoodLearner.java
@@ -65,7 +65,7 @@ public class GroundConflictNoGoodLearner {
 	 */
 	public int computeConflictFreeBackjumpingLevel(NoGood violatedNoGood) {
 		// If violatedNoGood is unary, backjump to decision level 0 if it can be satisfied.
-		if (violatedNoGood.size() == 1) {
+		if (violatedNoGood.isUnary()) {
 			int literal = violatedNoGood.getLiteral(0);
 			int literalDecisionLevel = assignment.getRealWeakDecisionLevel(atomOf(literal));
 			if (literalDecisionLevel > 0) {

--- a/src/main/java/at/ac/tuwien/kr/alpha/solver/learning/GroundConflictNoGoodLearner.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/solver/learning/GroundConflictNoGoodLearner.java
@@ -54,7 +54,26 @@ public class GroundConflictNoGoodLearner {
 	private final Assignment assignment;
 	private final AtomStore atomStore;
 
+	/**
+	 * Given a conflicting NoGood, computes a conflict-free backjumping level such that the given NoGood is not
+	 * violated.
+	 *
+	 * @param violatedNoGood the conflicting NoGood.
+	 * @return -1 if the violatedNoGood cannot be satisfied, otherwise
+	 * 	   0 if violatedNoGood is unary, and else
+	 * 	   the highest backjumping level such that the NoGood is no longer violated.
+	 */
 	public int computeConflictFreeBackjumpingLevel(NoGood violatedNoGood) {
+		// If violatedNoGood is unary, backjump to decision level 0 if it can be satisfied.
+		if (violatedNoGood.size() == 1) {
+			int literal = violatedNoGood.getLiteral(0);
+			int literalDecisionLevel = assignment.getRealWeakDecisionLevel(atomOf(literal));
+			if (literalDecisionLevel > 0) {
+				return 0;
+			} else {
+				return -1;
+			}
+		}
 		int highestDecisionLevel = -1;
 		int secondHighestDecisionLevel = -1;
 		int numAtomsInHighestLevel = 0;


### PR DESCRIPTION
Fix bug in computation of backjumping level for violated unary nogoods in GroundConflictNoGoodLearner and related issue with erroneous storage
of conflicting out-of-order assignments in TrailAssignment. Fixes #239.