### PR TITLE
Fix evaluation of negated external atoms (Issue #234)

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ComparisonLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ComparisonLiteral.java
@@ -121,7 +121,7 @@ public class ComparisonLiteral extends FixedInterpretationLiteral {
 	}
 
 	@Override
-	public List<Substitution> getSubstitutions(Substitution partialSubstitution) {
+	public List<Substitution> getSatisfyingSubstitutions(Substitution partialSubstitution) {
 		// Treat case where this is just comparison with all variables bound by partialSubstitution.
 		final Term left = getAtom().getTerms().get(0).substitute(partialSubstitution);
 		final Term right = getAtom().getTerms().get(1).substitute(partialSubstitution);

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
@@ -157,7 +157,7 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 	 * 
 	 * @param externalMethodResult The term lists obtained from evaluating the external atom
 	 *                (i.e. calling the java method) encapsulated by this literal
-	 * @return true iff no list in output equals the external atom's output term
+	 * @return true iff no list in externalMethodResult equals the external atom's output term
 	 *         list as substituted by the grounder, false otherwise
 	 */
 	private boolean isNegatedLiteralSatisfied(Set<List<ConstantTerm<?>>> externalMethodResult) {

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
@@ -148,7 +148,10 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 			}
 		} else {
 			if (this.isNegated()) {
-				return Collections.emptyList();
+				List<Substitution> retVal = new ArrayList<>();
+				retVal.add(partialSubstitution);
+				return retVal;
+				// return Collections.emptyList();
 			} else {
 				return this.buildSubstitutionsForOutputs(partialSubstitution, results);
 			}

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
@@ -119,7 +119,7 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 	}
 
 	@Override
-	public List<Substitution> getSubstitutions(Substitution partialSubstitution) {
+	public List<Substitution> getSatisfyingSubstitutions(Substitution partialSubstitution) {
 		List<Term> input = getAtom().getInput();
 		List<Term> substitutes = new ArrayList<>(input.size());
 
@@ -156,6 +156,23 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 				return this.buildSubstitutionsForOutputs(partialSubstitution, results);
 			}
 		}
+	}
+
+	/**
+	 * Checks whether this (negated) external literal is satisfied under the given
+	 * partial substitution.
+	 * Note that this method is only called on negated external literals that have
+	 * outputs. In that specific case, the literal itself does not bind any
+	 * variables, i.e. the literal is satisfied iff the output terms obtained
+	 * by evaluating the underlying external atom match the values to which the
+	 * respective output variables are bound in the partial substitution.
+	 * 
+	 * @param partialSubstitution
+	 * @param outputs
+	 * @return
+	 */
+	private boolean checkSatisfied(Substitution partialSubstitution, Set<List<ConstantTerm<?>>> outputs) {
+		return false;
 	}
 
 	private List<Substitution> buildSubstitutionsForOutputs(Substitution partialSubstitution, Set<List<ConstantTerm<?>>> outputs) {

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2018, the Alpha Team.
+ * Copyright (c) 2017-2020, the Alpha Team.
  * All rights reserved.
  * 
  * Additional changes made by Siemens.
@@ -27,14 +27,16 @@
  */
 package at.ac.tuwien.kr.alpha.common.atoms;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;
 import at.ac.tuwien.kr.alpha.common.terms.VariableTerm;
 import at.ac.tuwien.kr.alpha.grounder.Substitution;
-
-import java.util.*;
-
-import static java.util.Collections.emptyList;
 
 /**
  * Contains a potentially negated {@link ExternalAtom}.
@@ -44,14 +46,15 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 	public ExternalLiteral(ExternalAtom atom, boolean positive) {
 		super(atom, positive);
 	}
-	
+
 	@Override
 	public ExternalAtom getAtom() {
-		return (ExternalAtom)atom;
+		return (ExternalAtom) atom;
 	}
 
 	/**
-	 * Returns a new copy of this literal whose {@link Literal#isNegated()} status is inverted
+	 * Returns a new copy of this literal whose {@link Literal#isNegated()} status
+	 * is inverted
 	 */
 	@Override
 	public ExternalLiteral negate() {
@@ -68,14 +71,15 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 
 	@Override
 	public Set<VariableTerm> getBindingVariables() {
-		// If the external atom is negative, then all variables of input and output are non-binding
+		// If the external atom is negative, then all variables of input and output are
+		// non-binding
 		// and there are no binding variables (like for ordinary atoms).
 		// If the external atom is positive, then variables of output are binding.
 
 		if (!positive) {
 			return Collections.emptySet();
 		}
-		
+
 		List<Term> output = getAtom().getOutput();
 
 		Set<VariableTerm> binding = new HashSet<>(output.size());
@@ -93,7 +97,7 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 	public Set<VariableTerm> getNonBindingVariables() {
 		List<Term> input = getAtom().getInput();
 		List<Term> output = getAtom().getOutput();
-		
+
 		// External atoms have their input always non-binding, since they cannot
 		// be queried without some concrete input.
 		Set<VariableTerm> nonbindingVariables = new HashSet<>();
@@ -101,7 +105,8 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 			nonbindingVariables.addAll(term.getOccurringVariables());
 		}
 
-		// If the external atom is negative, then all variables of input and output are non-binding.
+		// If the external atom is negative, then all variables of input and output are
+		// non-binding.
 		if (!positive) {
 			for (Term out : output) {
 				if (out instanceof VariableTerm) {
@@ -116,33 +121,53 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 	@Override
 	public List<Substitution> getSubstitutions(Substitution partialSubstitution) {
 		List<Term> input = getAtom().getInput();
-		List<Term> output = getAtom().getOutput();
-		List<Substitution> substitutions = new ArrayList<>();
 		List<Term> substitutes = new ArrayList<>(input.size());
 
+		// evaluate the external atom
 		for (Term t : input) {
 			substitutes.add(t.substitute(partialSubstitution));
 		}
-
 		Set<List<ConstantTerm<?>>> results = getAtom().getInterpretation().evaluate(substitutes);
-
 		if (results == null) {
 			throw new NullPointerException("Predicate " + getPredicate().getName() + " returned null. It must return a Set.");
 		}
 
+		// determine ground substitutions of the literal
 		if (results.isEmpty()) {
-			return emptyList();
-		}
-
-		for (List<ConstantTerm<?>> bindings : results) {
-			if (bindings.size() < output.size()) {
-				throw new RuntimeException("Predicate " + getPredicate().getName() + " returned " + bindings.size() + " terms when at least " + output.size() + " were expected.");
+			// if the literal is negated and results are empty, the literal is "true",
+			// i.e. "not ATOM" holds because there are no instances of ATOM.
+			// communicate this by returning the partial substitution: since a negated
+			// external doesn't bind anything, it doesn't contribute to the full
+			// substitution of the rule body
+			if (this.isNegated()) {
+				List<Substitution> retVal = new ArrayList<>();
+				retVal.add(partialSubstitution);
+				return retVal;
+			} else {
+				return Collections.emptyList();
 			}
+		} else {
+			if (this.isNegated()) {
+				return Collections.emptyList();
+			} else {
+				return this.buildSubstitutionsForOutputs(partialSubstitution, results);
+			}
+		}
+	}
 
+	private List<Substitution> buildSubstitutionsForOutputs(Substitution partialSubstitution, Set<List<ConstantTerm<?>>> outputs) {
+		List<Substitution> retVal = new ArrayList<>();
+		List<Term> externalAtomOutputTerms = this.getAtom().getOutput();
+		for (List<ConstantTerm<?>> bindings : outputs) {
+			if (bindings.size() < externalAtomOutputTerms.size()) {
+				throw new RuntimeException(
+						"Predicate " + getPredicate().getName() + " returned " + bindings.size() + " terms when at least " + externalAtomOutputTerms.size()
+								+ " were expected.");
+			}
 			Substitution ith = new Substitution(partialSubstitution);
 			boolean skip = false;
-			for (int i = 0; i < output.size(); i++) {
-				Term out = output.get(i);
+			for (int i = 0; i < externalAtomOutputTerms.size(); i++) {
+				Term out = externalAtomOutputTerms.get(i);
 
 				if (out instanceof VariableTerm) {
 					ith.put((VariableTerm) out, bindings.get(i));
@@ -153,13 +178,11 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 					}
 				}
 			}
-
 			if (!skip) {
-				substitutions.add(ith);
+				retVal.add(ith);
 			}
 		}
-
-		return substitutions;
+		return retVal;
 	}
 
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
@@ -172,13 +172,13 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 				}
 			}
 			if (outputMatches) {
-				// we found one term list where all terms match the ground output terms of the
+				// We found one term list where all terms match the ground output terms of the
 				// external atom, therefore the atom is true and the (negative) literal false.
 				return false;
 			}
 		}
-		// we checked all term list and none matches the ground output terms, therefore
-		// the external atom is false, making the literal true
+		// We checked all term list and none matches the ground output terms, therefore
+		// the external atom is false, making the literal true.
 		return true;
 	}
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
@@ -155,18 +155,18 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 	 * in case of a negated external literal, the output variables are always
 	 * non-binding.
 	 * 
-	 * @param outputs The term lists obtained from evaluating the external atom
+	 * @param externalMethodResult The term lists obtained from evaluating the external atom
 	 *                (i.e. calling the java method) encapsulated by this literal
 	 * @return true iff no list in output equals the external atom's output term
 	 *         list as substituted by the grounder, false otherwise
 	 */
-	private boolean checkNegatedLiteralSatisfied(Set<List<ConstantTerm<?>>> outputs) {
+	private boolean checkNegatedLiteralSatisfied(Set<List<ConstantTerm<?>>> externalMethodResult) {
 		List<Term> externalAtomOutTerms = this.getAtom().getOutput();
 		boolean outputMatches;
-		for (List<ConstantTerm<?>> output : outputs) {
+		for (List<ConstantTerm<?>> resultTerms : externalMethodResult) {
 			outputMatches = true;
 			for (int i = 0; i < externalAtomOutTerms.size(); i++) {
-				if (!output.get(i).equals(externalAtomOutTerms.get(i))) {
+				if (!resultTerms.get(i).equals(externalAtomOutTerms.get(i))) {
 					outputMatches = false;
 					break;
 				}

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
@@ -71,8 +71,7 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 
 	@Override
 	public Set<VariableTerm> getBindingVariables() {
-		// If the external atom is negative, then all variables of input and output are
-		// non-binding
+		// If the external atom is negative, then all variables of input and output are non-binding
 		// and there are no binding variables (like for ordinary atoms).
 		// If the external atom is positive, then variables of output are binding.
 
@@ -123,7 +122,8 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 		List<Term> input = getAtom().getInput();
 		List<Term> substitutes = new ArrayList<>(input.size());
 
-		// evaluate the external atom
+		// In preparation for evaluating the external atom, set the input values according
+		// to the partial substitution supplied by the grounder.
 		for (Term t : input) {
 			substitutes.add(t.substitute(partialSubstitution));
 		}

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/ExternalLiteral.java
@@ -133,7 +133,7 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 		}
 
 		if (this.isNegated()) {
-			return this.checkNegatedLiteralSatisfied(results) ? Collections.singletonList(partialSubstitution) : Collections.emptyList();
+			return this.isNegatedLiteralSatisfied(results) ? Collections.singletonList(partialSubstitution) : Collections.emptyList();
 		} else {
 			return this.buildSubstitutionsForOutputs(partialSubstitution, results);
 		}
@@ -160,7 +160,7 @@ public class ExternalLiteral extends FixedInterpretationLiteral {
 	 * @return true iff no list in output equals the external atom's output term
 	 *         list as substituted by the grounder, false otherwise
 	 */
-	private boolean checkNegatedLiteralSatisfied(Set<List<ConstantTerm<?>>> externalMethodResult) {
+	private boolean isNegatedLiteralSatisfied(Set<List<ConstantTerm<?>>> externalMethodResult) {
 		List<Term> externalAtomOutTerms = this.getAtom().getOutput();
 		boolean outputMatches;
 		for (List<ConstantTerm<?>> resultTerms : externalMethodResult) {

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/FixedInterpretationLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/atoms/FixedInterpretationLiteral.java
@@ -32,15 +32,31 @@ import at.ac.tuwien.kr.alpha.grounder.Substitution;
 import java.util.List;
 
 /**
- * Represents a literal whose ground truth value(s) are independent of the current assignment.
- * Examples of atoms underlying such literals are builtin atoms and external atoms.
+ * Represents a literal whose ground truth value(s) are independent of the
+ * current assignment.
+ * Examples of atoms underlying such literals are builtin atoms and external
+ * atoms.
  * Copyright (c) 2017-2018, the Alpha Team.
  */
 public abstract class FixedInterpretationLiteral extends Literal {
-	
+
 	public FixedInterpretationLiteral(Atom atom, boolean positive) {
 		super(atom, positive);
 	}
-	
-	public abstract List<Substitution> getSubstitutions(Substitution partialSubstitution);
+
+	/**
+	 * Creates a list of {@link Substitution}s based on the given partial
+	 * substitution, such that
+	 * this {@link FixedInterpretationLiteral} is true in every returned
+	 * substitution.
+	 * In cases where this is not possible (because of conflicting variable
+	 * assignments in the partial substitution), getSatisfyingSubstitutions is
+	 * required to return an empty list
+	 * 
+	 * @param partialSubstitution a partial substitution that is required to bind
+	 *                            all variables that are non-binding in this literal
+	 * @return a list of substitutions, in each of which this literal is true, or an
+	 *         empty list if no such substitution exists
+	 */
+	public abstract List<Substitution> getSatisfyingSubstitutions(Substitution partialSubstitution);
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
@@ -485,7 +485,7 @@ public class NaiveGrounder extends BridgedGrounder implements ProgramAnalyzingGr
 			if (shallPushBackFixedInterpretationLiteral(substitutedLiteral)) {
 				return pushBackAndBindNextAtomInRule(groundingOrder, orderPosition, originalTolerance, remainingTolerance, partialSubstitution, currentAssignment);
 			}
-			final List<Substitution> substitutions = substitutedLiteral.getSubstitutions(partialSubstitution);
+			final List<Substitution> substitutions = substitutedLiteral.getSatisfyingSubstitutions(partialSubstitution);
 
 			if (substitutions.isEmpty()) {
 				// if FixedInterpretationLiteral cannot be satisfied now, it will never be

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/atoms/IntervalLiteral.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/atoms/IntervalLiteral.java
@@ -103,7 +103,7 @@ public class IntervalLiteral extends FixedInterpretationLiteral {
 	}
 
 	@Override
-	public List<Substitution> getSubstitutions(Substitution partialSubstitution) {
+	public List<Substitution> getSatisfyingSubstitutions(Substitution partialSubstitution) {
 		// Substitute variables occurring in the interval itself.
 		IntervalLiteral groundInterval = substitute(partialSubstitution);
 		// Generate all substitutions for the interval representing variable.

--- a/src/test/java/at/ac/tuwien/kr/alpha/api/externals/stdlib/AspStandardLibraryTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/api/externals/stdlib/AspStandardLibraryTest.java
@@ -99,21 +99,21 @@ public class AspStandardLibraryTest {
 		Assert.assertFalse(AspStandardLibrary.datetimeIsBefore(2015, 5, 13, 12, 1, 33, 2003, 1, 1, 0, 0, 1));
 		Assert.assertFalse(AspStandardLibrary.datetimeIsBefore(2022, 2, 22, 22, 22, 22, 2022, 2, 22, 22, 22, 22));
 	}
-	
+
 	@Test
 	public void datetimeEqual() {
 		Assert.assertTrue(AspStandardLibrary.datetimeIsEqual(1990, 2, 14, 15, 16, 17, 1990, 2, 14, 15, 16, 17));
 		Assert.assertFalse(AspStandardLibrary.datetimeIsEqual(2015, 5, 13, 12, 1, 33, 2003, 1, 1, 0, 0, 1));
-	}	
+	}
 
 	@Test
 	public void datetimeBeforeOrEqual() {
 		Assert.assertTrue(AspStandardLibrary.datetimeIsBeforeOrEqual(1990, 2, 14, 15, 16, 17, 1990, 3, 1, 0, 59, 1));
 		Assert.assertFalse(AspStandardLibrary.datetimeIsBeforeOrEqual(2015, 5, 13, 12, 1, 33, 2003, 1, 1, 0, 0, 1));
 		Assert.assertTrue(AspStandardLibrary.datetimeIsBeforeOrEqual(2022, 2, 22, 22, 22, 22, 2022, 2, 22, 22, 22, 22));
-		
+
 	}
-	
+
 	@Test
 	public void matchesRegex() {
 		Assert.assertTrue(AspStandardLibrary.stringMatchesRegex("Blaaaaa Blubbb!!", "Bla+ Blub+!!"));
@@ -162,6 +162,7 @@ public class AspStandardLibraryTest {
 		Alpha alpha = new Alpha();
 		Program prog = alpha.readProgram(InputConfig.forString(NEGATED_EXTERNAL_ASP));
 		Set<AnswerSet> answerSets = alpha.solve(prog).collect(Collectors.toSet());
+		Assert.assertEquals(31, answerSets.size());
 		// Verify every result string has length 6 and contains "foo"
 		for (AnswerSet as : answerSets) {
 			for (Atom atom : as.getPredicateInstances(Predicate.getInstance("resultstring", 1))) {

--- a/src/test/java/at/ac/tuwien/kr/alpha/api/externals/stdlib/AspStandardLibraryTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/api/externals/stdlib/AspStandardLibraryTest.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import at.ac.tuwien.kr.alpha.api.Alpha;
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
@@ -17,6 +19,8 @@ import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 import at.ac.tuwien.kr.alpha.config.InputConfig;
 
 public class AspStandardLibraryTest {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(AspStandardLibrary.class);
 
 	//@formatter:off
 	private static final String STRINGSTUFF_ASP =
@@ -29,6 +33,19 @@ public class AspStandardLibraryTest {
 			+ ":- resultstring(S), &stdlib_string_length[S](LEN), LEN != 6."
 			+ "containsFoo(S) :- resultstring(S), &stdlib_string_matches_regex[S, \".*foo.*\"]."
 			+ ":- resultstring(S), not containsFoo(S)."
+			+ "has_resultstring :- resultstring(_)."
+			+ ":- not has_resultstring.";
+	
+	// same as stringstuff asp, but without the "containsFoo" intermediate predicate
+	private static final String NEGATED_EXTERNAL_ASP =
+			"string(\"bla\")."
+			+ "string(\"blubb\")."
+			+ "string(\"foo\")."
+			+ "string(\"bar\")."
+			+ "{ strcat(S1, S2) } :- string(S1), string(S2)."
+			+ "resultstring(SCAT) :- strcat(S1, S2), &stdlib_string_concat[S1, S2](SCAT)."
+			+ ":- resultstring(S), &stdlib_string_length[S](LEN), LEN != 6."
+			+ ":- resultstring(S), not &stdlib_string_matches_regex[S, \".*foo.*\"]."
 			+ "has_resultstring :- resultstring(_)."
 			+ ":- not has_resultstring.";
 	//@formatter:on
@@ -119,6 +136,23 @@ public class AspStandardLibraryTest {
 		for (AnswerSet as : answerSets) {
 			for (Atom atom : as.getPredicateInstances(Predicate.getInstance("resultstring", 1))) {
 				String resultstring = ((ConstantTerm<String>) atom.getTerms().get(0)).getObject();
+				Assert.assertEquals(6, resultstring.length());
+				Assert.assertTrue(resultstring.contains("foo"));
+			}
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void negatedExternal() throws IOException {
+		Alpha alpha = new Alpha();
+		Program prog = alpha.readProgram(InputConfig.forString(NEGATED_EXTERNAL_ASP));
+		Set<AnswerSet> answerSets = alpha.solve(prog).collect(Collectors.toSet());
+		// Verify every result string has length 6 and contains "foo"
+		for (AnswerSet as : answerSets) {
+			for (Atom atom : as.getPredicateInstances(Predicate.getInstance("resultstring", 1))) {
+				String resultstring = ((ConstantTerm<String>) atom.getTerms().get(0)).getObject();
+				LOGGER.info("ResultSttring is {}", resultstring);
 				Assert.assertEquals(6, resultstring.length());
 				Assert.assertTrue(resultstring.contains("foo"));
 			}

--- a/src/test/java/at/ac/tuwien/kr/alpha/api/externals/stdlib/AspStandardLibraryTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/api/externals/stdlib/AspStandardLibraryTest.java
@@ -166,7 +166,7 @@ public class AspStandardLibraryTest {
 		for (AnswerSet as : answerSets) {
 			for (Atom atom : as.getPredicateInstances(Predicate.getInstance("resultstring", 1))) {
 				String resultstring = ((ConstantTerm<String>) atom.getTerms().get(0)).getObject();
-				LOGGER.info("ResultSttring is {}", resultstring);
+				LOGGER.debug("ResultString is {}", resultstring);
 				Assert.assertEquals(6, resultstring.length());
 				Assert.assertTrue(resultstring.contains("foo"));
 			}

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/FixedInterpretationLiteralsTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/FixedInterpretationLiteralsTest.java
@@ -1,0 +1,76 @@
+package at.ac.tuwien.kr.alpha.common.fixedinterpretations;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import at.ac.tuwien.kr.alpha.api.Alpha;
+import at.ac.tuwien.kr.alpha.api.externals.Externals;
+import at.ac.tuwien.kr.alpha.api.externals.stdlib.AspStandardLibrary;
+import at.ac.tuwien.kr.alpha.common.AnswerSet;
+import at.ac.tuwien.kr.alpha.common.Predicate;
+
+public class FixedInterpretationLiteralsTest {
+
+	@at.ac.tuwien.kr.alpha.api.externals.Predicate
+	public static boolean isOne(int value) {
+		return value == 1;
+	}
+
+	private static final String TEST_PROG = "positive_numeric_comparison :- 2 < 3."
+			+ "negative_numeric_comparison :- not 3 < 2."
+			+ "positive_unary_external :- &isOne[1]."
+			+ "negative_unary_external :- not &isOne[2]."
+			+ "positive_external_with_output :- "
+			+ "&stdlib_datetime_parse[\"01.01.2121 21:11:12\", \"dd.MM.yyyy HH:mm:ss\"](Y, MO, D, H, MI, S), Y = 2121, MO = 1, D = 1, H = 21, MI = 11, S = 12."
+			+ "negative_external_with_output :- Y = 2121, MO = 1, D = 1, H = 21, MI = 11, S = 12, "
+			+ "not &stdlib_datetime_parse[\"22.02.2222 21:11:12\", \"dd.MM.yyyy HH:mm:ss\"](Y, MO, D, H, MI, S).";
+
+	private AnswerSet answerSet;
+
+	public FixedInterpretationLiteralsTest() {
+		Alpha alpha = new Alpha();
+		Map<String, PredicateInterpretation> externals = new HashMap<>();
+		externals.putAll(Externals.scan(AspStandardLibrary.class));
+		externals.putAll(Externals.scan(FixedInterpretationLiteralsTest.class));
+		Optional<AnswerSet> answer = alpha.solve(alpha.readProgramString(TEST_PROG, externals)).findFirst();
+		if (!answer.isPresent()) {
+			throw new IllegalStateException("Test setup failed, no answer set!");
+		}
+		this.answerSet = answer.get();
+	}
+
+	@Test
+	public void positiveNumericComparison() {
+		Assert.assertTrue(this.answerSet.getPredicates().contains(Predicate.getInstance("positive_numeric_comparison", 0)));
+	}
+
+	@Test
+	public void negativeNumericComparison() {
+		Assert.assertTrue(this.answerSet.getPredicates().contains(Predicate.getInstance("negative_numeric_comparison", 0)));
+	}
+
+	@Test
+	public void positiveUnaryExternal() {
+		Assert.assertTrue(this.answerSet.getPredicates().contains(Predicate.getInstance("positive_unary_external", 0)));
+	}
+
+	@Test
+	public void negativeUnaryExternal() {
+		Assert.assertTrue(this.answerSet.getPredicates().contains(Predicate.getInstance("negative_unary_external", 0)));
+	}
+
+	@Test
+	public void positiveExternalWithOutput() {
+		Assert.assertTrue(this.answerSet.getPredicates().contains(Predicate.getInstance("positive_external_with_output", 0)));
+	}
+
+	@Test
+	public void negativeExternalWithOutput() {
+		Assert.assertTrue(this.answerSet.getPredicates().contains(Predicate.getInstance("negative_external_with_output", 0)));
+	}
+
+}

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/FixedInterpretationLiteralsTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/FixedInterpretationLiteralsTest.java
@@ -16,6 +16,8 @@ import at.ac.tuwien.kr.alpha.api.externals.Externals;
 import at.ac.tuwien.kr.alpha.api.externals.stdlib.AspStandardLibrary;
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
 import at.ac.tuwien.kr.alpha.common.Predicate;
+import at.ac.tuwien.kr.alpha.common.atoms.Atom;
+import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 
 public class FixedInterpretationLiteralsTest {
@@ -63,7 +65,8 @@ public class FixedInterpretationLiteralsTest {
 			+ "negative_external_multioutput :- START = \"Graz\", END = \"Salzburg\", not &connection[train_network](START, END)."
 			+ "negative_external_multioutput_dontfire :- START = \"Klagenfurt\", END = \"Villach\", not &connection[train_network](START, END)."
 			+ "positive_external_multioutput :- START = \"Klagenfurt\", END = \"Villach\", &connection[train_network](START, END)."
-			+ "positive_external_multioutput_dontfire :- START = \"Graz\", END = \"Salzburg\", &connection[train_network](START, END).";
+			+ "positive_external_multioutput_dontfire :- START = \"Graz\", END = \"Salzburg\", &connection[train_network](START, END)."
+			+ "positive_external_binding_output(START, END) :- &connection[train_network](START, END).";
 
 	private Alpha alpha;
 	private Map<String, PredicateInterpretation> externals;
@@ -169,6 +172,20 @@ public class FixedInterpretationLiteralsTest {
 		Assert.assertTrue(answer.isPresent());
 		AnswerSet answerSet = answer.get();
 		Assert.assertFalse(answerSet.getPredicates().contains(Predicate.getInstance("positive_external_multioutput_dontfire", 0)));
+	}
+
+	@Test
+	public void positiveExternalBindingOutput() {
+		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
+		Assert.assertTrue(answer.isPresent());
+		AnswerSet answerSet = answer.get();
+		Predicate pred = Predicate.getInstance("positive_external_binding_output", 2);
+		Assert.assertTrue(answerSet.getPredicates().contains(pred));
+		Set<Atom> instances = answerSet.getPredicateInstances(pred);
+		Assert.assertEquals(3, instances.size());
+		Assert.assertTrue(instances.contains(new BasicAtom(pred, ConstantTerm.getInstance("Klagenfurt"), ConstantTerm.getInstance("Villach"))));
+		Assert.assertTrue(instances.contains(new BasicAtom(pred, ConstantTerm.getInstance("Klagenfurt"), ConstantTerm.getInstance("Graz"))));
+		Assert.assertTrue(instances.contains(new BasicAtom(pred, ConstantTerm.getInstance("Villach"), ConstantTerm.getInstance("Salzburg"))));
 	}
 
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/FixedInterpretationLiteralsTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/FixedInterpretationLiteralsTest.java
@@ -28,8 +28,7 @@ public class FixedInterpretationLiteralsTest {
 	/**
 	 * Dummy method to test external atoms with more than one output term list.
 	 * Dummy input param which is not used exists solely to avoid producing an edge
-	 * case
-	 * where there is output, but no input
+	 * case where there is output, but no input
 	 */
 	@at.ac.tuwien.kr.alpha.api.externals.Predicate
 	public static Set<List<ConstantTerm<String>>> connection(String dummy) {

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/FixedInterpretationLiteralsTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/FixedInterpretationLiteralsTest.java
@@ -78,9 +78,7 @@ public class FixedInterpretationLiteralsTest {
 	@Test
 	public void positiveNumericComparison() {
 		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
-		if (!answer.isPresent()) {
-			throw new IllegalStateException("Test setup failed, no answer set!");
-		}
+		Assert.assertTrue(answer.isPresent());
 		AnswerSet answerSet = answer.get();
 		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("positive_numeric_comparison", 0)));
 	}
@@ -88,9 +86,7 @@ public class FixedInterpretationLiteralsTest {
 	@Test
 	public void negativeNumericComparison() {
 		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
-		if (!answer.isPresent()) {
-			throw new IllegalStateException("Test setup failed, no answer set!");
-		}
+		Assert.assertTrue(answer.isPresent());
 		AnswerSet answerSet = answer.get();
 		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("negative_numeric_comparison", 0)));
 	}
@@ -98,9 +94,7 @@ public class FixedInterpretationLiteralsTest {
 	@Test
 	public void positiveUnaryExternal() {
 		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
-		if (!answer.isPresent()) {
-			throw new IllegalStateException("Test setup failed, no answer set!");
-		}
+		Assert.assertTrue(answer.isPresent());
 		AnswerSet answerSet = answer.get();
 		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("positive_unary_external", 0)));
 	}
@@ -108,9 +102,7 @@ public class FixedInterpretationLiteralsTest {
 	@Test
 	public void negativeUnaryExternal() {
 		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
-		if (!answer.isPresent()) {
-			throw new IllegalStateException("Test setup failed, no answer set!");
-		}
+		Assert.assertTrue(answer.isPresent());
 		AnswerSet answerSet = answer.get();
 		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("negative_unary_external", 0)));
 	}
@@ -118,9 +110,7 @@ public class FixedInterpretationLiteralsTest {
 	@Test
 	public void positiveExternalWithOutput() {
 		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
-		if (!answer.isPresent()) {
-			throw new IllegalStateException("Test setup failed, no answer set!");
-		}
+		Assert.assertTrue(answer.isPresent());
 		AnswerSet answerSet = answer.get();
 		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("positive_external_with_output", 0)));
 	}
@@ -128,9 +118,7 @@ public class FixedInterpretationLiteralsTest {
 	@Test
 	public void positiveExternalWithOutputDontfire() {
 		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
-		if (!answer.isPresent()) {
-			throw new IllegalStateException("Test setup failed, no answer set!");
-		}
+		Assert.assertTrue(answer.isPresent());
 		AnswerSet answerSet = answer.get();
 		Assert.assertFalse(answerSet.getPredicates().contains(Predicate.getInstance("positive_external_with_output_dontfire", 0)));
 	}
@@ -138,9 +126,7 @@ public class FixedInterpretationLiteralsTest {
 	@Test
 	public void negativeExternalWithOutput() {
 		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
-		if (!answer.isPresent()) {
-			throw new IllegalStateException("Test setup failed, no answer set!");
-		}
+		Assert.assertTrue(answer.isPresent());
 		AnswerSet answerSet = answer.get();
 		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("negative_external_with_output", 0)));
 	}
@@ -148,9 +134,7 @@ public class FixedInterpretationLiteralsTest {
 	@Test
 	public void negativeExternalWithOutputDontfire() {
 		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
-		if (!answer.isPresent()) {
-			throw new IllegalStateException("Test setup failed, no answer set!");
-		}
+		Assert.assertTrue(answer.isPresent());
 		AnswerSet answerSet = answer.get();
 		Assert.assertFalse(answerSet.getPredicates().contains(Predicate.getInstance("negative_external_with_output_dontfire", 0)));
 	}
@@ -158,9 +142,7 @@ public class FixedInterpretationLiteralsTest {
 	@Test
 	public void negativeExternalMultioutput() {
 		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
-		if (!answer.isPresent()) {
-			throw new IllegalStateException("Test setup failed, no answer set!");
-		}
+		Assert.assertTrue(answer.isPresent());
 		AnswerSet answerSet = answer.get();
 		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("negative_external_multioutput", 0)));
 	}
@@ -168,9 +150,7 @@ public class FixedInterpretationLiteralsTest {
 	@Test
 	public void negativeExternalMultioutputDontfire() {
 		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
-		if (!answer.isPresent()) {
-			throw new IllegalStateException("Test setup failed, no answer set!");
-		}
+		Assert.assertTrue(answer.isPresent());
 		AnswerSet answerSet = answer.get();
 		Assert.assertFalse(answerSet.getPredicates().contains(Predicate.getInstance("negative_external_multioutput_dontfire", 0)));
 	}
@@ -178,9 +158,7 @@ public class FixedInterpretationLiteralsTest {
 	@Test
 	public void positiveExternalMultioutput() {
 		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
-		if (!answer.isPresent()) {
-			throw new IllegalStateException("Test setup failed, no answer set!");
-		}
+		Assert.assertTrue(answer.isPresent());
 		AnswerSet answerSet = answer.get();
 		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("positive_external_multioutput", 0)));
 	}
@@ -188,9 +166,7 @@ public class FixedInterpretationLiteralsTest {
 	@Test
 	public void positiveExternalMultioutputDontfire() {
 		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
-		if (!answer.isPresent()) {
-			throw new IllegalStateException("Test setup failed, no answer set!");
-		}
+		Assert.assertTrue(answer.isPresent());
 		AnswerSet answerSet = answer.get();
 		Assert.assertFalse(answerSet.getPredicates().contains(Predicate.getInstance("positive_external_multioutput_dontfire", 0)));
 	}

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/FixedInterpretationLiteralsTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/FixedInterpretationLiteralsTest.java
@@ -26,58 +26,101 @@ public class FixedInterpretationLiteralsTest {
 			+ "negative_unary_external :- not &isOne[2]."
 			+ "positive_external_with_output :- "
 			+ "&stdlib_datetime_parse[\"01.01.2121 21:11:12\", \"dd.MM.yyyy HH:mm:ss\"](Y, MO, D, H, MI, S), Y = 2121, MO = 1, D = 1, H = 21, MI = 11, S = 12."
+			+ "positive_external_with_output_dontfire :- "
+			+ "&stdlib_datetime_parse[\"01.01.2121 21:11:12\", \"dd.MM.yyyy HH:mm:ss\"](Y, MO, D, H, MI, S), Y = 2345, MO = 1, D = 1, H = 21, MI = 11, S = 12."
 			+ "negative_external_with_output :- Y = 2121, MO = 1, D = 1, H = 21, MI = 11, S = 12, "
 			+ "not &stdlib_datetime_parse[\"22.02.2222 21:11:12\", \"dd.MM.yyyy HH:mm:ss\"](Y, MO, D, H, MI, S)."
 			+ "negative_external_with_output_dontfire :- Y = 2222, MO = 2, D = 22, H = 21, MI = 11, S = 12,"
 			+ "not &stdlib_datetime_parse[\"22.02.2222 21:11:12\", \"dd.MM.yyyy HH:mm:ss\"](Y, MO, D, H, MI, S).";
 
-	private AnswerSet answerSet;
+	private Alpha alpha;
+	private Map<String, PredicateInterpretation> externals;
 
 	public FixedInterpretationLiteralsTest() {
-		Alpha alpha = new Alpha();
-		Map<String, PredicateInterpretation> externals = new HashMap<>();
-		externals.putAll(Externals.scan(AspStandardLibrary.class));
-		externals.putAll(Externals.scan(FixedInterpretationLiteralsTest.class));
-		Optional<AnswerSet> answer = alpha.solve(alpha.readProgramString(TEST_PROG, externals)).findFirst();
-		if (!answer.isPresent()) {
-			throw new IllegalStateException("Test setup failed, no answer set!");
-		}
-		this.answerSet = answer.get();
+		this.alpha = new Alpha();
+		this.externals = new HashMap<>();
+		this.externals.putAll(Externals.scan(AspStandardLibrary.class));
+		this.externals.putAll(Externals.scan(FixedInterpretationLiteralsTest.class));
 	}
 
 	@Test
 	public void positiveNumericComparison() {
-		Assert.assertTrue(this.answerSet.getPredicates().contains(Predicate.getInstance("positive_numeric_comparison", 0)));
+		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
+		if (!answer.isPresent()) {
+			throw new IllegalStateException("Test setup failed, no answer set!");
+		}
+		AnswerSet answerSet = answer.get();
+		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("positive_numeric_comparison", 0)));
 	}
 
 	@Test
 	public void negativeNumericComparison() {
-		Assert.assertTrue(this.answerSet.getPredicates().contains(Predicate.getInstance("negative_numeric_comparison", 0)));
+		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
+		if (!answer.isPresent()) {
+			throw new IllegalStateException("Test setup failed, no answer set!");
+		}
+		AnswerSet answerSet = answer.get();
+		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("negative_numeric_comparison", 0)));
 	}
 
 	@Test
 	public void positiveUnaryExternal() {
-		Assert.assertTrue(this.answerSet.getPredicates().contains(Predicate.getInstance("positive_unary_external", 0)));
+		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
+		if (!answer.isPresent()) {
+			throw new IllegalStateException("Test setup failed, no answer set!");
+		}
+		AnswerSet answerSet = answer.get();
+		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("positive_unary_external", 0)));
 	}
 
 	@Test
 	public void negativeUnaryExternal() {
-		Assert.assertTrue(this.answerSet.getPredicates().contains(Predicate.getInstance("negative_unary_external", 0)));
+		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
+		if (!answer.isPresent()) {
+			throw new IllegalStateException("Test setup failed, no answer set!");
+		}
+		AnswerSet answerSet = answer.get();
+		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("negative_unary_external", 0)));
 	}
 
 	@Test
 	public void positiveExternalWithOutput() {
-		Assert.assertTrue(this.answerSet.getPredicates().contains(Predicate.getInstance("positive_external_with_output", 0)));
+		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
+		if (!answer.isPresent()) {
+			throw new IllegalStateException("Test setup failed, no answer set!");
+		}
+		AnswerSet answerSet = answer.get();
+		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("positive_external_with_output", 0)));
 	}
 
 	@Test
+	public void positiveExternalWithOutputDontfire() {
+		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
+		if (!answer.isPresent()) {
+			throw new IllegalStateException("Test setup failed, no answer set!");
+		}
+		AnswerSet answerSet = answer.get();
+		Assert.assertFalse(answerSet.getPredicates().contains(Predicate.getInstance("positive_external_with_output_dontfire", 0)));
+	}	
+	
+	@Test
 	public void negativeExternalWithOutput() {
-		Assert.assertTrue(this.answerSet.getPredicates().contains(Predicate.getInstance("negative_external_with_output", 0)));
+		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
+		if (!answer.isPresent()) {
+			throw new IllegalStateException("Test setup failed, no answer set!");
+		}
+		AnswerSet answerSet = answer.get();
+		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("negative_external_with_output", 0)));
 	}
 
 	@Test
 	public void negativeExternalWithOutputDontfire() {
-		Assert.assertFalse(this.answerSet.getPredicates().contains(Predicate.getInstance("negative_external_with_output_dontfire", 0)));
+		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
+		if (!answer.isPresent()) {
+			throw new IllegalStateException("Test setup failed, no answer set!");
+		}
+		AnswerSet answerSet = answer.get();
+		Assert.assertFalse(answerSet.getPredicates().contains(Predicate.getInstance("negative_external_with_output_dontfire", 0)));
 	}
 
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/FixedInterpretationLiteralsTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/FixedInterpretationLiteralsTest.java
@@ -27,6 +27,8 @@ public class FixedInterpretationLiteralsTest {
 			+ "positive_external_with_output :- "
 			+ "&stdlib_datetime_parse[\"01.01.2121 21:11:12\", \"dd.MM.yyyy HH:mm:ss\"](Y, MO, D, H, MI, S), Y = 2121, MO = 1, D = 1, H = 21, MI = 11, S = 12."
 			+ "negative_external_with_output :- Y = 2121, MO = 1, D = 1, H = 21, MI = 11, S = 12, "
+			+ "not &stdlib_datetime_parse[\"22.02.2222 21:11:12\", \"dd.MM.yyyy HH:mm:ss\"](Y, MO, D, H, MI, S)."
+			+ "negative_external_with_output_dontfire :- Y = 2222, MO = 2, D = 22, H = 21, MI = 11, S = 12,"
 			+ "not &stdlib_datetime_parse[\"22.02.2222 21:11:12\", \"dd.MM.yyyy HH:mm:ss\"](Y, MO, D, H, MI, S).";
 
 	private AnswerSet answerSet;
@@ -71,6 +73,11 @@ public class FixedInterpretationLiteralsTest {
 	@Test
 	public void negativeExternalWithOutput() {
 		Assert.assertTrue(this.answerSet.getPredicates().contains(Predicate.getInstance("negative_external_with_output", 0)));
+	}
+
+	@Test
+	public void negativeExternalWithOutputDontfire() {
+		Assert.assertFalse(this.answerSet.getPredicates().contains(Predicate.getInstance("negative_external_with_output_dontfire", 0)));
 	}
 
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/FixedInterpretationLiteralsTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/fixedinterpretations/FixedInterpretationLiteralsTest.java
@@ -1,8 +1,12 @@
 package at.ac.tuwien.kr.alpha.common.fixedinterpretations;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -12,12 +16,37 @@ import at.ac.tuwien.kr.alpha.api.externals.Externals;
 import at.ac.tuwien.kr.alpha.api.externals.stdlib.AspStandardLibrary;
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
 import at.ac.tuwien.kr.alpha.common.Predicate;
+import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
 
 public class FixedInterpretationLiteralsTest {
 
 	@at.ac.tuwien.kr.alpha.api.externals.Predicate
 	public static boolean isOne(int value) {
 		return value == 1;
+	}
+
+	/**
+	 * Dummy method to test external atoms with more than one output term list.
+	 * Dummy input param which is not used exists solely to avoid producing an edge
+	 * case
+	 * where there is output, but no input
+	 */
+	@at.ac.tuwien.kr.alpha.api.externals.Predicate
+	public static Set<List<ConstantTerm<String>>> connection(String dummy) {
+		Set<List<ConstantTerm<String>>> retVal = new HashSet<>();
+		List<ConstantTerm<String>> l1 = new ArrayList<>();
+		List<ConstantTerm<String>> l2 = new ArrayList<>();
+		List<ConstantTerm<String>> l3 = new ArrayList<>();
+		l1.add(ConstantTerm.getInstance("Klagenfurt"));
+		l1.add(ConstantTerm.getInstance("Villach"));
+		l2.add(ConstantTerm.getInstance("Klagenfurt"));
+		l2.add(ConstantTerm.getInstance("Graz"));
+		l3.add(ConstantTerm.getInstance("Villach"));
+		l3.add(ConstantTerm.getInstance("Salzburg"));
+		retVal.add(l1);
+		retVal.add(l2);
+		retVal.add(l3);
+		return retVal;
 	}
 
 	private static final String TEST_PROG = "positive_numeric_comparison :- 2 < 3."
@@ -31,7 +60,11 @@ public class FixedInterpretationLiteralsTest {
 			+ "negative_external_with_output :- Y = 2121, MO = 1, D = 1, H = 21, MI = 11, S = 12, "
 			+ "not &stdlib_datetime_parse[\"22.02.2222 21:11:12\", \"dd.MM.yyyy HH:mm:ss\"](Y, MO, D, H, MI, S)."
 			+ "negative_external_with_output_dontfire :- Y = 2222, MO = 2, D = 22, H = 21, MI = 11, S = 12,"
-			+ "not &stdlib_datetime_parse[\"22.02.2222 21:11:12\", \"dd.MM.yyyy HH:mm:ss\"](Y, MO, D, H, MI, S).";
+			+ "not &stdlib_datetime_parse[\"22.02.2222 21:11:12\", \"dd.MM.yyyy HH:mm:ss\"](Y, MO, D, H, MI, S)."
+			+ "negative_external_multioutput :- START = \"Graz\", END = \"Salzburg\", not &connection[train_network](START, END)."
+			+ "negative_external_multioutput_dontfire :- START = \"Klagenfurt\", END = \"Villach\", not &connection[train_network](START, END)."
+			+ "positive_external_multioutput :- START = \"Klagenfurt\", END = \"Villach\", &connection[train_network](START, END)."
+			+ "positive_external_multioutput_dontfire :- START = \"Graz\", END = \"Salzburg\", &connection[train_network](START, END).";
 
 	private Alpha alpha;
 	private Map<String, PredicateInterpretation> externals;
@@ -101,8 +134,8 @@ public class FixedInterpretationLiteralsTest {
 		}
 		AnswerSet answerSet = answer.get();
 		Assert.assertFalse(answerSet.getPredicates().contains(Predicate.getInstance("positive_external_with_output_dontfire", 0)));
-	}	
-	
+	}
+
 	@Test
 	public void negativeExternalWithOutput() {
 		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
@@ -121,6 +154,46 @@ public class FixedInterpretationLiteralsTest {
 		}
 		AnswerSet answerSet = answer.get();
 		Assert.assertFalse(answerSet.getPredicates().contains(Predicate.getInstance("negative_external_with_output_dontfire", 0)));
+	}
+
+	@Test
+	public void negativeExternalMultioutput() {
+		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
+		if (!answer.isPresent()) {
+			throw new IllegalStateException("Test setup failed, no answer set!");
+		}
+		AnswerSet answerSet = answer.get();
+		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("negative_external_multioutput", 0)));
+	}
+
+	@Test
+	public void negativeExternalMultioutputDontfire() {
+		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
+		if (!answer.isPresent()) {
+			throw new IllegalStateException("Test setup failed, no answer set!");
+		}
+		AnswerSet answerSet = answer.get();
+		Assert.assertFalse(answerSet.getPredicates().contains(Predicate.getInstance("negative_external_multioutput_dontfire", 0)));
+	}
+
+	@Test
+	public void positiveExternalMultioutput() {
+		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
+		if (!answer.isPresent()) {
+			throw new IllegalStateException("Test setup failed, no answer set!");
+		}
+		AnswerSet answerSet = answer.get();
+		Assert.assertTrue(answerSet.getPredicates().contains(Predicate.getInstance("positive_external_multioutput", 0)));
+	}
+
+	@Test
+	public void positiveExternalMultioutputDontfire() {
+		Optional<AnswerSet> answer = this.alpha.solve(this.alpha.readProgramString(TEST_PROG, this.externals)).findFirst();
+		if (!answer.isPresent()) {
+			throw new IllegalStateException("Test setup failed, no answer set!");
+		}
+		AnswerSet answerSet = answer.get();
+		Assert.assertFalse(answerSet.getPredicates().contains(Predicate.getInstance("positive_external_multioutput_dontfire", 0)));
 	}
 
 }


### PR DESCRIPTION
Fixes the issue described in #234.

For external atoms that have outputs, if the literal is negated, the truth value of the literal is determined as follows:
```The (negated external) literal lit is true iff no list of terms TL exists in the external atom's output, such that the terms in TL equal the substituted values of the literal's output variables (i.e. the values those variables are bound to by the grounder)```

Also, `FixedInterpretationLiteral#getSubstitutions` renamed to `getSatisfyingSubstitutions` to properly represent method semantics in the method name.