### PR TITLE
Command Line Interface - Make separator string for atoms within printed answer set configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 	implementation group: 'commons-cli',        name: 'commons-cli',          version: '1.3.1'
 	implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.1'
 	implementation group: 'org.apache.commons', name: 'commons-lang3',        version: '3.6'
+	implementation group: 'org.apache.commons', name: 'commons-text',         version: '1.8'
 	implementation group: 'org.reflections',    name: 'reflections',          version: '0.9.11'
 	implementation group: 'org.apache.poi',     name: 'poi',                  version: '4.1.1'
 	implementation group: 'org.apache.poi',     name: 'poi-ooxml',            version: '4.1.1'

--- a/src/main/java/at/ac/tuwien/kr/alpha/Main.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/Main.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 import at.ac.tuwien.kr.alpha.api.Alpha;
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
 import at.ac.tuwien.kr.alpha.common.AnswerSetFormatter;
-import at.ac.tuwien.kr.alpha.common.BasicAnswerSetFormatter;
+import at.ac.tuwien.kr.alpha.common.SimpleAnswerSetFormatter;
 import at.ac.tuwien.kr.alpha.common.Program;
 import at.ac.tuwien.kr.alpha.config.AlphaConfig;
 import at.ac.tuwien.kr.alpha.config.CommandLineParser;
@@ -104,7 +104,7 @@ public class Main {
 		if (!alpha.getConfig().isQuiet()) {
 			AtomicInteger counter = new AtomicInteger(0);
 			final BiConsumer<Integer, AnswerSet> answerSetHandler;
-			final AnswerSetFormatter<String> fmt = new BasicAnswerSetFormatter(alpha.getConfig().getAtomSeparator());
+			final AnswerSetFormatter<String> fmt = new SimpleAnswerSetFormatter(alpha.getConfig().getAtomSeparator());
 			BiConsumer<Integer, AnswerSet> stdoutPrinter = (n, as) -> {
 				System.out.println("Answer set " + Integer.toString(n) + ":" + System.lineSeparator() + fmt.format(as));
 			};

--- a/src/main/java/at/ac/tuwien/kr/alpha/Main.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/Main.java
@@ -42,6 +42,8 @@ import org.slf4j.LoggerFactory;
 
 import at.ac.tuwien.kr.alpha.api.Alpha;
 import at.ac.tuwien.kr.alpha.common.AnswerSet;
+import at.ac.tuwien.kr.alpha.common.AnswerSetFormatter;
+import at.ac.tuwien.kr.alpha.common.BasicAnswerSetFormatter;
 import at.ac.tuwien.kr.alpha.common.Program;
 import at.ac.tuwien.kr.alpha.config.AlphaConfig;
 import at.ac.tuwien.kr.alpha.config.CommandLineParser;
@@ -102,8 +104,9 @@ public class Main {
 		if (!alpha.getConfig().isQuiet()) {
 			AtomicInteger counter = new AtomicInteger(0);
 			final BiConsumer<Integer, AnswerSet> answerSetHandler;
+			final AnswerSetFormatter<String> fmt = new BasicAnswerSetFormatter(alpha.getConfig().getAtomSeparator());
 			BiConsumer<Integer, AnswerSet> stdoutPrinter = (n, as) -> {
-				System.out.println("Answer set " + Integer.toString(n) + ":" + System.lineSeparator() + as.toString());
+				System.out.println("Answer set " + Integer.toString(n) + ":" + System.lineSeparator() + fmt.format(as));
 			};
 			if (inputCfg.isWriteAnswerSetsAsXlsx()) {
 				BiConsumer<Integer, AnswerSet> xlsxWriter = new AnswerSetToXlsxWriter(inputCfg.getAnswerSetFileOutputPath());

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/BasicAnswerSetFormatter.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/BasicAnswerSetFormatter.java
@@ -1,0 +1,33 @@
+package at.ac.tuwien.kr.alpha.common;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
+
+import at.ac.tuwien.kr.alpha.common.atoms.Atom;
+
+public class BasicAnswerSetFormatter implements AnswerSetFormatter<String> {
+
+	private final String atomSeparator;
+
+	public BasicAnswerSetFormatter(String atomSeparator) {
+		this.atomSeparator = atomSeparator;
+	}
+
+	@Override
+	public String format(AnswerSet answerSet) {
+		List<String> predicateInstanceStrings = new ArrayList<>();
+		for (Predicate p : answerSet.getPredicates()) {
+			SortedSet<Atom> instances;
+			if ((instances = answerSet.getPredicateInstances(p)) == null || instances.isEmpty()) {
+				predicateInstanceStrings.add(p.getName());
+			} else {
+				List<String> atomStrings = instances.stream().map((atom) -> atom.toString()).collect(Collectors.toList());
+				predicateInstanceStrings.add(String.join(this.atomSeparator, atomStrings));
+			}
+		}
+		return "{ " + String.join(this.atomSeparator, predicateInstanceStrings) + " }";
+	}
+
+}

--- a/src/main/java/at/ac/tuwien/kr/alpha/common/SimpleAnswerSetFormatter.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/common/SimpleAnswerSetFormatter.java
@@ -7,11 +7,11 @@ import java.util.stream.Collectors;
 
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
 
-public class BasicAnswerSetFormatter implements AnswerSetFormatter<String> {
+public class SimpleAnswerSetFormatter implements AnswerSetFormatter<String> {
 
 	private final String atomSeparator;
 
-	public BasicAnswerSetFormatter(String atomSeparator) {
+	public SimpleAnswerSetFormatter(String atomSeparator) {
 		this.atomSeparator = atomSeparator;
 	}
 

--- a/src/main/java/at/ac/tuwien/kr/alpha/config/CommandLineParser.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/config/CommandLineParser.java
@@ -27,8 +27,13 @@
  */
 package at.ac.tuwien.kr.alpha.config;
 
-import at.ac.tuwien.kr.alpha.solver.BinaryNoGoodPropagationEstimation;
-import at.ac.tuwien.kr.alpha.solver.heuristics.BranchingHeuristicFactory.Heuristic;
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -36,15 +41,12 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayOutputStream;
-import java.io.FileInputStream;
-import java.io.PrintWriter;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Consumer;
+import at.ac.tuwien.kr.alpha.solver.BinaryNoGoodPropagationEstimation;
+import at.ac.tuwien.kr.alpha.solver.heuristics.BranchingHeuristicFactory.Heuristic;
 
 /**
  * Parses given argument lists (as passed when Alpha is called from command line) into {@link AlphaConfig}s and {@link InputConfig}s.
@@ -417,7 +419,7 @@ public class CommandLineParser {
 	}
 
 	private void handleAtomSeparator(Option opt, SystemConfig cfg) {
-		cfg.setAtomSeparator(opt.getValue(SystemConfig.DEFAULT_ATOM_SEPARATOR));
+		cfg.setAtomSeparator(StringEscapeUtils.unescapeJava(opt.getValue(SystemConfig.DEFAULT_ATOM_SEPARATOR)));
 	}
 	
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/config/CommandLineParser.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/config/CommandLineParser.java
@@ -113,7 +113,7 @@ public class CommandLineParser {
 			.build();
 	private static final Option OPT_NO_NOGOOD_DELETION = Option.builder("dnd").longOpt("disableNoGoodDeletion")
 			.desc("disable the deletion of (learned, little active) nogoods (default: " 
-							+ SystemConfig.DEFAULT_DISABLE_NOGOOD_DELETION + ")")
+					+ SystemConfig.DEFAULT_DISABLE_NOGOOD_DELETION + ")")
 			.build();
 	private static final Option OPT_GROUNDER_TOLERANCE_CONSTRAINTS = Option.builder("gtc").longOpt("grounderToleranceConstraints")
 			.desc("grounder tolerance for constraints (default: " + SystemConfig.DEFAULT_GROUNDER_TOLERANCE_CONSTRAINTS + ")")
@@ -125,7 +125,11 @@ public class CommandLineParser {
 			.build();
 	private static final Option OPT_GROUNDER_ACCUMULATOR_ENABLED = Option.builder("acc").longOpt("enableAccumulator")
 			.desc("activates the accumulator grounding strategy by disabling removal of instances from grounder memory in certain cases (default: "
-						+ SystemConfig.DEFAULT_GROUNDER_ACCUMULATOR_ENABLED + ")")
+					+ SystemConfig.DEFAULT_GROUNDER_ACCUMULATOR_ENABLED + ")")
+			.build();
+	private static final Option OPT_OUTPUT_ATOM_SEPARATOR = Option.builder("sep").longOpt("atomSeparator").hasArg(true).argName("separator")
+			.desc("a character (sequence) to use s separator for atoms in printed answer sets. (default: "
+					+ SystemConfig.DEFAULT_ATOM_SEPARATOR + ")")
 			.build();
 	//@formatter:on
 
@@ -162,6 +166,7 @@ public class CommandLineParser {
 		CommandLineParser.CLI_OPTS.addOption(CommandLineParser.OPT_GROUNDER_TOLERANCE_CONSTRAINTS);
 		CommandLineParser.CLI_OPTS.addOption(CommandLineParser.OPT_GROUNDER_TOLERANCE_RULES);
 		CommandLineParser.CLI_OPTS.addOption(CommandLineParser.OPT_GROUNDER_ACCUMULATOR_ENABLED);
+		CommandLineParser.CLI_OPTS.addOption(CommandLineParser.OPT_OUTPUT_ATOM_SEPARATOR);
 	}
 
 	/*
@@ -208,6 +213,7 @@ public class CommandLineParser {
 		this.globalOptionHandlers.put(CommandLineParser.OPT_GROUNDER_TOLERANCE_CONSTRAINTS.getOpt(), this::handleGrounderToleranceConstraints);
 		this.globalOptionHandlers.put(CommandLineParser.OPT_GROUNDER_TOLERANCE_RULES.getOpt(), this::handleGrounderToleranceRules);
 		this.globalOptionHandlers.put(CommandLineParser.OPT_GROUNDER_ACCUMULATOR_ENABLED.getOpt(), this::handleGrounderNoInstanceRemoval);
+		this.globalOptionHandlers.put(CommandLineParser.OPT_OUTPUT_ATOM_SEPARATOR.getOpt(), this::handleAtomSeparator);
 
 		this.inputOptionHandlers.put(CommandLineParser.OPT_NUM_ANSWER_SETS.getOpt(), this::handleNumAnswerSets);
 		this.inputOptionHandlers.put(CommandLineParser.OPT_INPUT.getOpt(), this::handleInput);
@@ -410,4 +416,8 @@ public class CommandLineParser {
 		cfg.setGrounderAccumulatorEnabled(true);
 	}
 
+	private void handleAtomSeparator(Option opt, SystemConfig cfg) {
+		cfg.setAtomSeparator(opt.getValue(SystemConfig.DEFAULT_ATOM_SEPARATOR));
+	}
+	
 }

--- a/src/main/java/at/ac/tuwien/kr/alpha/config/SystemConfig.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/config/SystemConfig.java
@@ -60,6 +60,7 @@ public class SystemConfig {
 	public static final String DEFAULT_GROUNDER_TOLERANCE_CONSTRAINTS = GrounderHeuristicsConfiguration.STRICT_STRING;
 	public static final String DEFAULT_GROUNDER_TOLERANCE_RULES = GrounderHeuristicsConfiguration.STRICT_STRING;
 	public static final boolean DEFAULT_GROUNDER_ACCUMULATOR_ENABLED = false;
+	public static final String DEFAULT_ATOM_SEPARATOR = ", ";
 
 	private String grounderName = SystemConfig.DEFAULT_GROUNDER_NAME;
 	private String solverName = SystemConfig.DEFAULT_SOLVER_NAME;
@@ -79,6 +80,7 @@ public class SystemConfig {
 	private String grounderToleranceConstraints = DEFAULT_GROUNDER_TOLERANCE_CONSTRAINTS;
 	private String grounderToleranceRules = DEFAULT_GROUNDER_TOLERANCE_RULES;
 	private boolean grounderAccumulatorEnabled = DEFAULT_GROUNDER_ACCUMULATOR_ENABLED;
+	private String atomSeparator = DEFAULT_ATOM_SEPARATOR;
 
 	public String getGrounderName() {
 		return this.grounderName;
@@ -234,5 +236,13 @@ public class SystemConfig {
 
 	public void setGrounderAccumulatorEnabled(boolean grounderAccumulatorEnabled) {
 		this.grounderAccumulatorEnabled = grounderAccumulatorEnabled;
+	}
+
+	public String getAtomSeparator() {
+		return this.atomSeparator;
+	}
+
+	public void setAtomSeparator(String atomSeparator) {
+		this.atomSeparator = atomSeparator;
 	}
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/AnswerSetFormatterTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/AnswerSetFormatterTest.java
@@ -7,7 +7,7 @@ public class AnswerSetFormatterTest {
 
 	@Test
 	public void basicFormatterWithSeparator() {
-		AnswerSetFormatter<String> fmt = new BasicAnswerSetFormatter(" bla ");
+		AnswerSetFormatter<String> fmt = new SimpleAnswerSetFormatter(" bla ");
 		AnswerSet as = new AnswerSetBuilder().predicate("p").instance("a").predicate("q").instance("b").build();
 		String formatted = fmt.format(as);
 		Assert.assertEquals("{ p(\"a\") bla q(\"b\") }", formatted);

--- a/src/test/java/at/ac/tuwien/kr/alpha/common/AnswerSetFormatterTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/common/AnswerSetFormatterTest.java
@@ -1,0 +1,16 @@
+package at.ac.tuwien.kr.alpha.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AnswerSetFormatterTest {
+
+	@Test
+	public void basicFormatterWithSeparator() {
+		AnswerSetFormatter<String> fmt = new BasicAnswerSetFormatter(" bla ");
+		AnswerSet as = new AnswerSetBuilder().predicate("p").instance("a").predicate("q").instance("b").build();
+		String formatted = fmt.format(as);
+		Assert.assertEquals("{ p(\"a\") bla q(\"b\") }", formatted);
+	}
+
+}

--- a/src/test/java/at/ac/tuwien/kr/alpha/config/CommandLineParserTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/config/CommandLineParserTest.java
@@ -58,15 +58,15 @@ public class CommandLineParserTest {
 	@Test
 	public void basicUsageWithFile() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig ctx = parser.parseCommandLine(new String[] {"-i", "someFile.asp", "-i", "someOtherFile.asp" });
-		assertEquals(Arrays.asList(new String[] {"someFile.asp", "someOtherFile.asp" }), ctx.getInputConfig().getFiles());
+		AlphaConfig ctx = parser.parseCommandLine(new String[] {"-i", "someFile.asp", "-i", "someOtherFile.asp"});
+		assertEquals(Arrays.asList(new String[] {"someFile.asp", "someOtherFile.asp"}), ctx.getInputConfig().getFiles());
 	}
 
 	@Test
 	public void basicUsageWithString() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig ctx = parser.parseCommandLine(new String[] {"-str", "b :- a.", "-str", "c :- a, b." });
-		assertEquals(Arrays.asList(new String[] {"b :- a.", "c :- a, b." }), ctx.getInputConfig().getAspStrings());
+		AlphaConfig ctx = parser.parseCommandLine(new String[] {"-str", "b :- a.", "-str", "c :- a, b."});
+		assertEquals(Arrays.asList(new String[] {"b :- a.", "c :- a, b."}), ctx.getInputConfig().getAspStrings());
 	}
 
 	@Test(expected = ParseException.class)
@@ -78,19 +78,19 @@ public class CommandLineParserTest {
 	@Test
 	public void moreThanOneInputSource() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		parser.parseCommandLine(new String[] {"-i", "a.b", "-i", "b.c", "-str", "aString." });
+		parser.parseCommandLine(new String[] {"-i", "a.b", "-i", "b.c", "-str", "aString."});
 	}
 
 	@Test(expected = ParseException.class)
 	public void invalidUsageMissingInputFlag() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		parser.parseCommandLine(new String[] {"-i", "a.b", "b.c" });
+		parser.parseCommandLine(new String[] {"-i", "a.b", "b.c"});
 	}
 
 	@Test
 	public void numAnswerSets() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig ctx = parser.parseCommandLine(new String[] {"-str", "aString.", "-n", "00435" });
+		AlphaConfig ctx = parser.parseCommandLine(new String[] {"-str", "aString.", "-n", "00435"});
 		assertEquals(435, ctx.getInputConfig().getNumAnswerSets());
 	}
 
@@ -103,55 +103,55 @@ public class CommandLineParserTest {
 	@Test
 	public void replay() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-rc", "\"1,2, 3\"" });
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-rc", "\"1,2, 3\""});
 		assertEquals(Arrays.asList(1, 2, 3), alphaConfig.getAlphaConfig().getReplayChoices());
 	}
 
 	@Test(expected = ParseException.class)
 	public void replayWithNonNumericLiteral() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		parser.parseCommandLine(new String[] {"-str", "aString.", "-rc", "\"1, 2, x\"" });
+		parser.parseCommandLine(new String[] {"-str", "aString.", "-rc", "\"1, 2, x\""});
 	}
 
 	@Test
 	public void grounderToleranceConstraints_numeric() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-gtc", "-1" });
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-gtc", "-1"});
 		assertEquals("-1", alphaConfig.getAlphaConfig().getGrounderToleranceConstraints());
 	}
 
 	@Test
 	public void grounderToleranceConstraints_string() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-gtc", "strict" });
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-gtc", "strict"});
 		assertEquals("strict", alphaConfig.getAlphaConfig().getGrounderToleranceConstraints());
 	}
 
 	@Test
 	public void grounderToleranceRules_numeric() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-gtr", "1" });
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-gtr", "1"});
 		assertEquals("1", alphaConfig.getAlphaConfig().getGrounderToleranceRules());
 	}
 
 	@Test
 	public void grounderToleranceRules_string() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-gtr", "permissive" });
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-gtr", "permissive"});
 		assertEquals("permissive", alphaConfig.getAlphaConfig().getGrounderToleranceRules());
 	}
 
 	@Test
 	public void noInstanceRemoval() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-acc" });
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-acc"});
 		assertTrue(alphaConfig.getAlphaConfig().isGrounderAccumulatorEnabled());
 	}
 
 	@Test
 	public void atomSeparator() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig cfg = parser.parseCommandLine(new String[] {"-str", "aString.", "-sep", "some-string" });
+		AlphaConfig cfg = parser.parseCommandLine(new String[] {"-str", "aString.", "-sep", "some-string"});
 		assertEquals("some-string", cfg.getAlphaConfig().getAtomSeparator());
 	}
 

--- a/src/test/java/at/ac/tuwien/kr/alpha/config/CommandLineParserTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/config/CommandLineParserTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertTrue;
 public class CommandLineParserTest {
 
 	private static final String DEFAULT_COMMAND_LINE = "java -jar Alpha-bundled.jar";
-	private static final Consumer<String> DEFAULT_ABORT_ACTION = (msg) -> {};
+	private static final Consumer<String> DEFAULT_ABORT_ACTION = (msg) -> { };
 
 	/**
 	 * Tests that a help message is written to the consumer configured in the
@@ -51,22 +51,22 @@ public class CommandLineParserTest {
 	public void help() throws ParseException {
 		StringBuilder bld = new StringBuilder();
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, (msg) -> bld.append(msg));
-		parser.parseCommandLine(new String[] { "-h" });
+		parser.parseCommandLine(new String[] {"-h" });
 		assertTrue(!(bld.toString().isEmpty()));
 	}
 
 	@Test
 	public void basicUsageWithFile() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig ctx = parser.parseCommandLine(new String[] { "-i", "someFile.asp", "-i", "someOtherFile.asp" });
-		assertEquals(Arrays.asList(new String[] { "someFile.asp", "someOtherFile.asp" }), ctx.getInputConfig().getFiles());
+		AlphaConfig ctx = parser.parseCommandLine(new String[] {"-i", "someFile.asp", "-i", "someOtherFile.asp" });
+		assertEquals(Arrays.asList(new String[] {"someFile.asp", "someOtherFile.asp" }), ctx.getInputConfig().getFiles());
 	}
 
 	@Test
 	public void basicUsageWithString() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig ctx = parser.parseCommandLine(new String[] { "-str", "b :- a.", "-str", "c :- a, b." });
-		assertEquals(Arrays.asList(new String[] { "b :- a.", "c :- a, b." }), ctx.getInputConfig().getAspStrings());
+		AlphaConfig ctx = parser.parseCommandLine(new String[] {"-str", "b :- a.", "-str", "c :- a, b." });
+		assertEquals(Arrays.asList(new String[] {"b :- a.", "c :- a, b." }), ctx.getInputConfig().getAspStrings());
 	}
 
 	@Test(expected = ParseException.class)
@@ -78,19 +78,19 @@ public class CommandLineParserTest {
 	@Test
 	public void moreThanOneInputSource() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		parser.parseCommandLine(new String[] { "-i", "a.b", "-i", "b.c", "-str", "aString." });
+		parser.parseCommandLine(new String[] {"-i", "a.b", "-i", "b.c", "-str", "aString." });
 	}
 
 	@Test(expected = ParseException.class)
 	public void invalidUsageMissingInputFlag() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		parser.parseCommandLine(new String[] { "-i", "a.b", "b.c" });
+		parser.parseCommandLine(new String[] {"-i", "a.b", "b.c" });
 	}
 
 	@Test
 	public void numAnswerSets() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig ctx = parser.parseCommandLine(new String[] { "-str", "aString.", "-n", "00435" });
+		AlphaConfig ctx = parser.parseCommandLine(new String[] {"-str", "aString.", "-n", "00435" });
 		assertEquals(435, ctx.getInputConfig().getNumAnswerSets());
 	}
 
@@ -103,55 +103,55 @@ public class CommandLineParserTest {
 	@Test
 	public void replay() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] { "-str", "aString.", "-rc", "\"1,2, 3\"" });
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-rc", "\"1,2, 3\"" });
 		assertEquals(Arrays.asList(1, 2, 3), alphaConfig.getAlphaConfig().getReplayChoices());
 	}
 
 	@Test(expected = ParseException.class)
 	public void replayWithNonNumericLiteral() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		parser.parseCommandLine(new String[] { "-str", "aString.", "-rc", "\"1, 2, x\"" });
+		parser.parseCommandLine(new String[] {"-str", "aString.", "-rc", "\"1, 2, x\"" });
 	}
 
 	@Test
 	public void grounderToleranceConstraints_numeric() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] { "-str", "aString.", "-gtc", "-1" });
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-gtc", "-1" });
 		assertEquals("-1", alphaConfig.getAlphaConfig().getGrounderToleranceConstraints());
 	}
 
 	@Test
 	public void grounderToleranceConstraints_string() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] { "-str", "aString.", "-gtc", "strict" });
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-gtc", "strict" });
 		assertEquals("strict", alphaConfig.getAlphaConfig().getGrounderToleranceConstraints());
 	}
 
 	@Test
 	public void grounderToleranceRules_numeric() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] { "-str", "aString.", "-gtr", "1" });
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-gtr", "1" });
 		assertEquals("1", alphaConfig.getAlphaConfig().getGrounderToleranceRules());
 	}
 
 	@Test
 	public void grounderToleranceRules_string() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] { "-str", "aString.", "-gtr", "permissive" });
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-gtr", "permissive" });
 		assertEquals("permissive", alphaConfig.getAlphaConfig().getGrounderToleranceRules());
 	}
 
 	@Test
 	public void noInstanceRemoval() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] { "-str", "aString.", "-acc" });
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] {"-str", "aString.", "-acc" });
 		assertTrue(alphaConfig.getAlphaConfig().isGrounderAccumulatorEnabled());
 	}
 
 	@Test
 	public void atomSeparator() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig cfg = parser.parseCommandLine(new String[] { "-str", "aString.", "-sep", "some-string" });
+		AlphaConfig cfg = parser.parseCommandLine(new String[] {"-str", "aString.", "-sep", "some-string" });
 		assertEquals("some-string", cfg.getAlphaConfig().getAtomSeparator());
 	}
 

--- a/src/test/java/at/ac/tuwien/kr/alpha/config/CommandLineParserTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/config/CommandLineParserTest.java
@@ -110,7 +110,7 @@ public class CommandLineParserTest {
 	@Test(expected = ParseException.class)
 	public void replayWithNonNumericLiteral() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[]{"-str", "aString.", "-rc", "\"1, 2, x\""});
+		parser.parseCommandLine(new String[]{"-str", "aString.", "-rc", "\"1, 2, x\""});
 	}
 
 	@Test

--- a/src/test/java/at/ac/tuwien/kr/alpha/config/CommandLineParserTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/config/CommandLineParserTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertTrue;
 public class CommandLineParserTest {
 
 	private static final String DEFAULT_COMMAND_LINE = "java -jar Alpha-bundled.jar";
-	private static final Consumer<String> DEFAULT_ABORT_ACTION = (msg) -> { };
+	private static final Consumer<String> DEFAULT_ABORT_ACTION = (msg) -> {};
 
 	/**
 	 * Tests that a help message is written to the consumer configured in the
@@ -51,22 +51,22 @@ public class CommandLineParserTest {
 	public void help() throws ParseException {
 		StringBuilder bld = new StringBuilder();
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, (msg) -> bld.append(msg));
-		parser.parseCommandLine(new String[] {"-h"});
+		parser.parseCommandLine(new String[] { "-h" });
 		assertTrue(!(bld.toString().isEmpty()));
 	}
 
 	@Test
 	public void basicUsageWithFile() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig ctx = parser.parseCommandLine(new String[] {"-i", "someFile.asp", "-i", "someOtherFile.asp"});
-		assertEquals(Arrays.asList(new String[] {"someFile.asp", "someOtherFile.asp"}), ctx.getInputConfig().getFiles());
+		AlphaConfig ctx = parser.parseCommandLine(new String[] { "-i", "someFile.asp", "-i", "someOtherFile.asp" });
+		assertEquals(Arrays.asList(new String[] { "someFile.asp", "someOtherFile.asp" }), ctx.getInputConfig().getFiles());
 	}
 
 	@Test
 	public void basicUsageWithString() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig ctx = parser.parseCommandLine(new String[] {"-str", "b :- a.", "-str", "c :- a, b."});
-		assertEquals(Arrays.asList(new String[] {"b :- a.", "c :- a, b."}), ctx.getInputConfig().getAspStrings());
+		AlphaConfig ctx = parser.parseCommandLine(new String[] { "-str", "b :- a.", "-str", "c :- a, b." });
+		assertEquals(Arrays.asList(new String[] { "b :- a.", "c :- a, b." }), ctx.getInputConfig().getAspStrings());
 	}
 
 	@Test(expected = ParseException.class)
@@ -78,22 +78,22 @@ public class CommandLineParserTest {
 	@Test
 	public void moreThanOneInputSource() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		parser.parseCommandLine(new String[] {"-i", "a.b", "-i", "b.c", "-str", "aString."});
+		parser.parseCommandLine(new String[] { "-i", "a.b", "-i", "b.c", "-str", "aString." });
 	}
 
 	@Test(expected = ParseException.class)
 	public void invalidUsageMissingInputFlag() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		parser.parseCommandLine(new String[] {"-i", "a.b", "b.c"});
+		parser.parseCommandLine(new String[] { "-i", "a.b", "b.c" });
 	}
 
 	@Test
 	public void numAnswerSets() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig ctx = parser.parseCommandLine(new String[] {"-str", "aString.", "-n", "00435"});
+		AlphaConfig ctx = parser.parseCommandLine(new String[] { "-str", "aString.", "-n", "00435" });
 		assertEquals(435, ctx.getInputConfig().getNumAnswerSets());
 	}
-	
+
 	@Test(expected = ParseException.class)
 	public void noInputGiven() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
@@ -103,49 +103,56 @@ public class CommandLineParserTest {
 	@Test
 	public void replay() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[]{"-str", "aString.", "-rc", "\"1,2, 3\""});
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] { "-str", "aString.", "-rc", "\"1,2, 3\"" });
 		assertEquals(Arrays.asList(1, 2, 3), alphaConfig.getAlphaConfig().getReplayChoices());
 	}
 
 	@Test(expected = ParseException.class)
 	public void replayWithNonNumericLiteral() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		parser.parseCommandLine(new String[]{"-str", "aString.", "-rc", "\"1, 2, x\""});
+		parser.parseCommandLine(new String[] { "-str", "aString.", "-rc", "\"1, 2, x\"" });
 	}
 
 	@Test
 	public void grounderToleranceConstraints_numeric() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[]{"-str", "aString.", "-gtc", "-1"});
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] { "-str", "aString.", "-gtc", "-1" });
 		assertEquals("-1", alphaConfig.getAlphaConfig().getGrounderToleranceConstraints());
 	}
 
 	@Test
 	public void grounderToleranceConstraints_string() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[]{"-str", "aString.", "-gtc", "strict"});
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] { "-str", "aString.", "-gtc", "strict" });
 		assertEquals("strict", alphaConfig.getAlphaConfig().getGrounderToleranceConstraints());
 	}
 
 	@Test
 	public void grounderToleranceRules_numeric() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[]{"-str", "aString.", "-gtr", "1"});
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] { "-str", "aString.", "-gtr", "1" });
 		assertEquals("1", alphaConfig.getAlphaConfig().getGrounderToleranceRules());
 	}
 
 	@Test
 	public void grounderToleranceRules_string() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[]{"-str", "aString.", "-gtr", "permissive"});
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] { "-str", "aString.", "-gtr", "permissive" });
 		assertEquals("permissive", alphaConfig.getAlphaConfig().getGrounderToleranceRules());
 	}
 
 	@Test
 	public void noInstanceRemoval() throws ParseException {
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
-		AlphaConfig alphaConfig = parser.parseCommandLine(new String[]{"-str", "aString.", "-acc"});
+		AlphaConfig alphaConfig = parser.parseCommandLine(new String[] { "-str", "aString.", "-acc" });
 		assertTrue(alphaConfig.getAlphaConfig().isGrounderAccumulatorEnabled());
+	}
+
+	@Test
+	public void atomSeparator() throws ParseException {
+		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, DEFAULT_ABORT_ACTION);
+		AlphaConfig cfg = parser.parseCommandLine(new String[] { "-str", "aString.", "-sep", "some-string" });
+		assertEquals("some-string", cfg.getAlphaConfig().getAtomSeparator());
 	}
 
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/config/CommandLineParserTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/config/CommandLineParserTest.java
@@ -51,7 +51,7 @@ public class CommandLineParserTest {
 	public void help() throws ParseException {
 		StringBuilder bld = new StringBuilder();
 		CommandLineParser parser = new CommandLineParser(DEFAULT_COMMAND_LINE, (msg) -> bld.append(msg));
-		parser.parseCommandLine(new String[] {"-h" });
+		parser.parseCommandLine(new String[] {"-h"});
 		assertTrue(!(bld.toString().isEmpty()));
 	}
 


### PR DESCRIPTION
Adds a new command line parameter (`sep <separator>`) in order to influence the way answer sets are printed to `stdout`.

Example:
```
$ java -jar Alpha-bundled.jar -str "a. b(c). d(e, f)." -sep ",\n"
```
formats the answer set as:
```
{ a,
b(c),
d(e, f) }
```