### PR TITLE
Substitution lazy cloning

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
@@ -333,7 +333,7 @@ public class NaiveGrounder extends BridgedGrounder implements ProgramAnalyzingGr
 				for (Instance instance : modifiedWorkingMemory.getRecentlyAddedInstances()) {
 					// Check instance if it matches with the atom.
 
-					final Substitution unifier = Substitution.unify(firstBindingAtom.startingLiteral, instance, Substitution.EMPTY_SUBSTITUTION);
+					final Substitution unifier = Substitution.specializeSubstitution(firstBindingAtom.startingLiteral, instance, Substitution.EMPTY_SUBSTITUTION);
 
 					if (unifier == null) {
 						continue;

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounder.java
@@ -333,7 +333,7 @@ public class NaiveGrounder extends BridgedGrounder implements ProgramAnalyzingGr
 				for (Instance instance : modifiedWorkingMemory.getRecentlyAddedInstances()) {
 					// Check instance if it matches with the atom.
 
-					final Substitution unifier = Substitution.unify(firstBindingAtom.startingLiteral, instance, new Substitution());
+					final Substitution unifier = Substitution.unify(firstBindingAtom.startingLiteral, instance, Substitution.EMPTY_SUBSTITUTION);
 
 					if (unifier == null) {
 						continue;

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/Substitution.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/Substitution.java
@@ -78,7 +78,7 @@ public class Substitution {
 	 * Helper class to lazily clone the input substitution of Substitution.specializeSubstitution only when needed.
 	 */
 	private static class SpecializationHelper {
-		Substitution returnSubstitution;
+		Substitution updatedSubstitution;	// Is null for as long as the given partial substitution is not extended, afterwards holds the updated/extended/specialized substitution.
 
 		Substitution unify(List<Term> termList, Instance instance, Substitution partialSubstitution) {
 			for (int i = 0; i < termList.size(); i++) {
@@ -86,11 +86,11 @@ public class Substitution {
 					return null;
 				}
 			}
-			if (returnSubstitution == null) {
+			if (updatedSubstitution == null) {
 				// All terms unify but there was no need to assign a new variable, return the input substitution.
 				return partialSubstitution;
 			}
-			return returnSubstitution;
+			return updatedSubstitution;
 		}
 
 		boolean unifyTerms(Term termNonGround, Term termGround, Substitution partialSubstitution) {
@@ -104,17 +104,17 @@ public class Substitution {
 				VariableTerm variableTerm = (VariableTerm) termNonGround;
 				// Left term is variable, bind it to the right term. Use original substitution if it has
 				// not been cloned yet.
-				Term bound = (returnSubstitution == null ? partialSubstitution : returnSubstitution).eval(variableTerm);
+				Term bound = (updatedSubstitution == null ? partialSubstitution : updatedSubstitution).eval(variableTerm); // Get variable binding, either from input substitution if it has not been updated yet, or from the cloned/updated substitution.
 				if (bound != null) {
 					// Variable is already bound, return true if binding is the same as the current ground term.
 					return termGround == bound;
 				}
 				// Record new variable binding.
-				if (returnSubstitution == null) {
-					// Clone substitution if it was not yet.
-					returnSubstitution = new Substitution(partialSubstitution);
+				if (updatedSubstitution == null) {
+					// Clone substitution if it was not yet updated.
+					updatedSubstitution = new Substitution(partialSubstitution);
 				}
-				returnSubstitution.put(variableTerm, termGround);
+				updatedSubstitution.put(variableTerm, termGround);
 				return true;
 			} else if (termNonGround instanceof FunctionTerm && termGround instanceof FunctionTerm) {
 				// Both terms are function terms

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/instantiation/AbstractLiteralInstantiationStrategy.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/instantiation/AbstractLiteralInstantiationStrategy.java
@@ -105,7 +105,7 @@ public abstract class AbstractLiteralInstantiationStrategy implements LiteralIns
 		Substitution currentInstanceSubstitution;
 		Atom atomForCurrentInstance;
 		for (Instance instance : candidateInstances) {
-			currentInstanceSubstitution = Substitution.unify(atomToSubstitute, instance, new Substitution(partialSubstitution));
+			currentInstanceSubstitution = Substitution.unify(atomToSubstitute, instance, partialSubstitution);
 			if (currentInstanceSubstitution == null) {
 				// Instance does not unify with partialSubstitution, move on to the next instance.
 				continue;

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/instantiation/AbstractLiteralInstantiationStrategy.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/instantiation/AbstractLiteralInstantiationStrategy.java
@@ -105,7 +105,7 @@ public abstract class AbstractLiteralInstantiationStrategy implements LiteralIns
 		Substitution currentInstanceSubstitution;
 		Atom atomForCurrentInstance;
 		for (Instance instance : candidateInstances) {
-			currentInstanceSubstitution = Substitution.unify(atomToSubstitute, instance, partialSubstitution);
+			currentInstanceSubstitution = Substitution.specializeSubstitution(atomToSubstitute, instance, partialSubstitution);
 			if (currentInstanceSubstitution == null) {
 				// Instance does not unify with partialSubstitution, move on to the next instance.
 				continue;

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/transformation/StratifiedEvaluation.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/transformation/StratifiedEvaluation.java
@@ -1,21 +1,5 @@
 package at.ac.tuwien.kr.alpha.grounder.transformation;
 
-import org.apache.commons.collections4.SetUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
-
 import at.ac.tuwien.kr.alpha.common.Predicate;
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
@@ -37,6 +21,21 @@ import at.ac.tuwien.kr.alpha.grounder.instantiation.AssignmentStatus;
 import at.ac.tuwien.kr.alpha.grounder.instantiation.LiteralInstantiationResult;
 import at.ac.tuwien.kr.alpha.grounder.instantiation.LiteralInstantiator;
 import at.ac.tuwien.kr.alpha.grounder.instantiation.WorkingMemoryBasedInstantiationStrategy;
+import org.apache.commons.collections4.SetUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
 
 /**
  * Evaluates the stratifiable part of a given (analyzed) ASP program.
@@ -237,7 +236,7 @@ public class StratifiedEvaluation extends ProgramTransformation<AnalyzedProgram,
 			return Collections.emptyList();
 		}
 		for (Instance instance : instances) {
-			Substitution unifyingSubstitution = Substitution.unify(lit, instance, new Substitution());
+			Substitution unifyingSubstitution = Substitution.unify(lit, instance, Substitution.EMPTY_SUBSTITUTION);
 			if (unifyingSubstitution != null) {
 				retVal.add(unifyingSubstitution);
 			}

--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/transformation/StratifiedEvaluation.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/transformation/StratifiedEvaluation.java
@@ -236,7 +236,7 @@ public class StratifiedEvaluation extends ProgramTransformation<AnalyzedProgram,
 			return Collections.emptyList();
 		}
 		for (Instance instance : instances) {
-			Substitution unifyingSubstitution = Substitution.unify(lit, instance, Substitution.EMPTY_SUBSTITUTION);
+			Substitution unifyingSubstitution = Substitution.specializeSubstitution(lit, instance, Substitution.EMPTY_SUBSTITUTION);
 			if (unifyingSubstitution != null) {
 				retVal.add(unifyingSubstitution);
 			}

--- a/src/test/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounderTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/grounder/NaiveGrounderTest.java
@@ -25,22 +25,6 @@
  */
 package at.ac.tuwien.kr.alpha.grounder;
 
-import static at.ac.tuwien.kr.alpha.TestUtil.atom;
-import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.TRUE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import at.ac.tuwien.kr.alpha.api.Alpha;
 import at.ac.tuwien.kr.alpha.common.Assignment;
 import at.ac.tuwien.kr.alpha.common.AtomStore;
@@ -59,6 +43,21 @@ import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
 import at.ac.tuwien.kr.alpha.grounder.parser.ProgramPartParser;
 import at.ac.tuwien.kr.alpha.solver.ThriceTruth;
 import at.ac.tuwien.kr.alpha.solver.TrailAssignment;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static at.ac.tuwien.kr.alpha.TestUtil.atom;
+import static at.ac.tuwien.kr.alpha.solver.ThriceTruth.TRUE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests {@link NaiveGrounder}
@@ -182,7 +181,7 @@ public class NaiveGrounderTest {
 	}
 
 	/**
-	 * Tests the method {@link NaiveGrounder#getGroundInstantiations(NonGroundRule, RuleGroundingOrder, Substitution, Assignment)} on a predefined program:
+	 * Tests the method {@link NaiveGrounder#getGroundInstantiations(InternalRule, RuleGroundingOrder, Substitution, Assignment)} on a predefined program:
 	 * <code>
 	 *  p1(1). q1(1). <br/>
 	 * 	x :- p1(X), p2(X), q1(Y), q2(Y). <br/>
@@ -223,7 +222,7 @@ public class NaiveGrounderTest {
 
 		grounder.bootstrap();
 		TrailAssignment currentAssignment = new TrailAssignment(atomStore);
-		final Substitution subst1 = Substitution.unify(startingLiteral, new Instance(ConstantTerm.getInstance(1)), new Substitution());
+		final Substitution subst1 = Substitution.specializeSubstitution(startingLiteral, new Instance(ConstantTerm.getInstance(1)), Substitution.EMPTY_SUBSTITUTION);
 		final BindingResult bindingResult = grounder.getGroundInstantiations(nonGroundRule, groundingOrder, subst1, currentAssignment);
 
 		assertEquals(expectNoGoods, bindingResult.size() > 0);
@@ -264,7 +263,7 @@ public class NaiveGrounderTest {
 	}
 
 	/**
-	 * Tests if {@link NaiveGrounder#getGroundInstantiations(NonGroundRule, RuleGroundingOrder, Substitution, Assignment)}
+	 * Tests if {@link NaiveGrounder#getGroundInstantiations(InternalRule, RuleGroundingOrder, Substitution, Assignment)}
 	 * produces ground instantiations for the rule with ID {@code ruleID} in {@code program} when {@code startingLiteral}
 	 * unified with the numeric instance {@code startingInstance} is used as starting literal and {@code b(1)} is assigned
 	 * {@code bTruth}.
@@ -284,7 +283,7 @@ public class NaiveGrounderTest {
 
 		grounder.bootstrap();
 		final InternalRule nonGroundRule = grounder.getNonGroundRule(ruleID);
-		final Substitution substStartingLiteral = Substitution.unify(startingLiteral, new Instance(ConstantTerm.getInstance(startingInstance)), new Substitution());
+		final Substitution substStartingLiteral = Substitution.specializeSubstitution(startingLiteral, new Instance(ConstantTerm.getInstance(startingInstance)), Substitution.EMPTY_SUBSTITUTION);
 		final BindingResult bindingResult = grounder.getGroundInstantiations(nonGroundRule, nonGroundRule.getGroundingOrders().groundingOrders.get(startingLiteral), substStartingLiteral, currentAssignment);
 		assertEquals(expectNoGoods, bindingResult.size() > 0);
 	}
@@ -358,7 +357,7 @@ public class NaiveGrounderTest {
 	}
 
 	/**
-	 * Tests if {@link NaiveGrounder#getGroundInstantiations(NonGroundRule, RuleGroundingOrder, Substitution, Assignment)}
+	 * Tests if {@link NaiveGrounder#getGroundInstantiations(InternalRule, RuleGroundingOrder, Substitution, Assignment)}
 	 * produces ground instantiations for the rule with ID {@code ruleID} in {@code program} when {@code startingLiteral}
 	 * unified with the numeric instance {@code startingInstance} is used as starting literal and the following
 	 * additional conditions are established:
@@ -397,7 +396,7 @@ public class NaiveGrounderTest {
 
 		grounder.bootstrap();
 		final InternalRule nonGroundRule = grounder.getNonGroundRule(ruleID);
-		final Substitution substStartingLiteral = Substitution.unify(startingLiteral, new Instance(ConstantTerm.getInstance(startingInstance)), new Substitution());
+		final Substitution substStartingLiteral = Substitution.specializeSubstitution(startingLiteral, new Instance(ConstantTerm.getInstance(startingInstance)), Substitution.EMPTY_SUBSTITUTION);
 		final BindingResult bindingResult = grounder.getGroundInstantiations(nonGroundRule, nonGroundRule.getGroundingOrders().groundingOrders.get(startingLiteral), substStartingLiteral, currentAssignment);
 		assertEquals(expectNoGoods, bindingResult.size() > 0);
 		if (bindingResult.size() > 0) {

--- a/src/test/java/at/ac/tuwien/kr/alpha/grounder/NoGoodGeneratorTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/grounder/NoGoodGeneratorTest.java
@@ -56,7 +56,7 @@ public class NoGoodGeneratorTest {
 	private static final VariableTerm Y = VariableTerm.getInstance("Y");
 
 	/**
-	 * Calls {@link NoGoodGenerator#collectNegLiterals(NonGroundRule, Substitution)}, which puts the atom occurring
+	 * Calls {@link NoGoodGenerator#collectNegLiterals(InternalRule, Substitution)}, which puts the atom occurring
 	 * negatively in a rule into the atom store. It is then checked whether the atom in the atom store is positive.
 	 */
 	@Test
@@ -73,8 +73,8 @@ public class NoGoodGeneratorTest {
 		Grounder grounder = GrounderFactory.getInstance("naive", program, atomStore, true);
 		NoGoodGenerator noGoodGenerator = ((NaiveGrounder) grounder).noGoodGenerator;
 		Substitution substitution = new Substitution();
-		substitution.unifyTerms(X, A);
-		substitution.unifyTerms(Y, B);
+		substitution.put(X, A);
+		substitution.put(Y, B);
 		List<Integer> collectedNeg = noGoodGenerator.collectNegLiterals(rule, substitution);
 		assertEquals(1, collectedNeg.size());
 		String negAtomString = atomStore.atomToString(atomOf(collectedNeg.get(0)));

--- a/src/test/java/at/ac/tuwien/kr/alpha/grounder/SubstitutionTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/grounder/SubstitutionTest.java
@@ -27,13 +27,6 @@
  */
 package at.ac.tuwien.kr.alpha.grounder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
-
-import java.util.Arrays;
-
 import at.ac.tuwien.kr.alpha.common.Predicate;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicLiteral;
@@ -48,36 +41,53 @@ import at.ac.tuwien.kr.alpha.common.terms.VariableTerm;
 import at.ac.tuwien.kr.alpha.grounder.atoms.RuleAtom;
 import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
 import at.ac.tuwien.kr.alpha.test.util.SubstitutionTestUtil;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
 
 public class SubstitutionTest {
-	static final ProgramParser PARSER = new ProgramParser();
+	private static final ProgramParser PARSER = new ProgramParser();
 
-	static final ConstantTerm<?> A = ConstantTerm.getSymbolicInstance("a");
-	static final ConstantTerm<?> B = ConstantTerm.getSymbolicInstance("b");
-	static final ConstantTerm<?> C = ConstantTerm.getSymbolicInstance("c");
+	private static final ConstantTerm<?> A = ConstantTerm.getSymbolicInstance("a");
+	private static final ConstantTerm<?> B = ConstantTerm.getSymbolicInstance("b");
+	private static final ConstantTerm<?> C = ConstantTerm.getSymbolicInstance("c");
 
-	static final VariableTerm X = VariableTerm.getInstance("X");
-	static final VariableTerm Y = VariableTerm.getInstance("Y");
+	private static final VariableTerm X = VariableTerm.getInstance("X");
+	private static final VariableTerm Y = VariableTerm.getInstance("Y");
+	private static final BasicAtom PX = new BasicAtom(Predicate.getInstance("p", 1), X);
+	private static final BasicAtom PY = new BasicAtom(Predicate.getInstance("p", 1), Y);
+	private static final Instance PA = new Instance(A);
+	private static final Instance PB = new Instance(B);
 
 	@Test
-	public void unifyTermsSimpleBinding() throws Exception {
+	public void putSimpleBinding() {
 		Substitution substitution = new Substitution();
-		substitution.unifyTerms(Y, A);
+		substitution.put(Y, A);
 		assertEquals(A, substitution.eval(Y));
 	}
 
 	@Test
-	public void unifyTermsFunctionTermBinding() throws Exception {
+	public void specializeTermsSimpleBinding() {
+		Substitution substitution = Substitution.specializeSubstitution(PY, PA, Substitution.EMPTY_SUBSTITUTION);
+		assertEquals(A, substitution.eval(Y));
+	}
+
+	@Test
+	public void specializeTermsFunctionTermBinding() {
 		Substitution substitution = new Substitution();
 		substitution.put(Y, A);
 
 		FunctionTerm groundFunctionTerm = FunctionTerm.getInstance("f", B, C);
+		Instance qfBC = new Instance(groundFunctionTerm);
 		Term nongroundFunctionTerm = FunctionTerm.getInstance("f", B, X);
+		BasicAtom qfBX = new BasicAtom(Predicate.getInstance("q", 2), nongroundFunctionTerm);
 
-		substitution.unifyTerms(nongroundFunctionTerm, groundFunctionTerm);
+		Substitution substitution1 = Substitution.specializeSubstitution(qfBX, qfBC, substitution);
 
-		assertEquals(C, substitution.eval(X));
-		assertEquals(A, substitution.eval(Y));
+		assertEquals(C, substitution1.eval(X));
+		assertEquals(A, substitution1.eval(Y));
 	}
 
 	@Test
@@ -94,11 +104,22 @@ public class SubstitutionTest {
 	public void groundAndPrintRule() {
 		BasicRule rule = PARSER.parse("x :- p(X,Y), not q(X,Y).").getRules().get(0);
 		InternalRule nonGroundRule = InternalRule.fromNormalRule(NormalRule.fromBasicRule(rule));
-		Substitution substitution = new Substitution();
-		substitution.unifyTerms(X, A);
-		substitution.unifyTerms(Y, B);
-		String printedString = SubstitutionTestUtil.groundAndPrintRule(nonGroundRule, substitution);
+		Substitution substitution1 = Substitution.specializeSubstitution(PX, PA, Substitution.EMPTY_SUBSTITUTION);
+		Substitution substitution2 = Substitution.specializeSubstitution(PY, PB, substitution1);
+		String printedString = SubstitutionTestUtil.groundAndPrintRule(nonGroundRule, substitution2);
 		assertEquals("x :- p(a, b), not q(a, b).", printedString);
+	}
+
+	@Test
+	public void specializeBasicAtom() {
+		Predicate p = Predicate.getInstance("p", 2);
+		BasicAtom atom = new BasicAtom(p, Arrays.asList(X, Y));
+		Instance instance = new Instance(A, B);
+		Substitution substitution = Substitution.specializeSubstitution(atom, instance, Substitution.EMPTY_SUBSTITUTION);
+		BasicAtom substituted = atom.substitute(substitution);
+		assertEquals(p, substituted.getPredicate());
+		assertEquals(A, substituted.getTerms().get(0));
+		assertEquals(B, substituted.getTerms().get(1));
 	}
 
 	private void substituteBasicAtomLiteral(boolean negated) {
@@ -106,8 +127,8 @@ public class SubstitutionTest {
 		BasicAtom atom = new BasicAtom(p, Arrays.asList(X, Y));
 		Literal literal = new BasicLiteral(atom, !negated);
 		Substitution substitution = new Substitution();
-		substitution.unifyTerms(X, A);
-		substitution.unifyTerms(Y, B);
+		substitution.put(X, A);
+		substitution.put(Y, B);
 		literal = literal.substitute(substitution);
 		assertEquals(p, literal.getPredicate());
 		assertEquals(A, literal.getTerms().get(0));
@@ -128,9 +149,8 @@ public class SubstitutionTest {
 	private void groundLiteralToString(boolean negated) {
 		Predicate p = Predicate.getInstance("p", 2);
 		BasicAtom atom = new BasicAtom(p, Arrays.asList(X, Y));
-		Substitution substitution = new Substitution();
-		substitution.unifyTerms(X, A);
-		substitution.unifyTerms(Y, B);
+		Substitution substitution1 = Substitution.specializeSubstitution(PX, PA, Substitution.EMPTY_SUBSTITUTION);
+		Substitution substitution = Substitution.specializeSubstitution(PY, PB, substitution1);
 		String printedString = SubstitutionTestUtil.groundLiteralToString(atom.toLiteral(!negated), substitution, true);
 		assertEquals((negated ? "not " : "") + "p(a, b)", printedString);
 	}
@@ -139,12 +159,11 @@ public class SubstitutionTest {
 	public void substitutionFromString() {
 		BasicRule rule = PARSER.parse("x :- p(X,Y), not q(X,Y).").getRules().get(0);
 		InternalRule nonGroundRule = InternalRule.fromNormalRule(NormalRule.fromBasicRule(rule));
-		Substitution substitution = new Substitution();
-		substitution.unifyTerms(X, A);
-		substitution.unifyTerms(Y, B);
+		Substitution substitution1 = Substitution.specializeSubstitution(PX, PA, Substitution.EMPTY_SUBSTITUTION);
+		Substitution substitution = Substitution.specializeSubstitution(PY, PB, substitution1);
 		RuleAtom ruleAtom = new RuleAtom(nonGroundRule, substitution);
 		String substitutionString = (String) ((ConstantTerm<?>) ruleAtom.getTerms().get(1)).getObject();
 		Substitution fromString = Substitution.fromString(substitutionString);
-		assertTrue(substitution.equals(fromString));
+		assertEquals(substitution, fromString);
 	}
 }

--- a/src/test/java/at/ac/tuwien/kr/alpha/grounder/UnifierTest.java
+++ b/src/test/java/at/ac/tuwien/kr/alpha/grounder/UnifierTest.java
@@ -28,27 +28,16 @@
 
 package at.ac.tuwien.kr.alpha.grounder;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
-import java.util.Arrays;
-
-import at.ac.tuwien.kr.alpha.common.Predicate;
 import at.ac.tuwien.kr.alpha.common.atoms.Atom;
 import at.ac.tuwien.kr.alpha.common.atoms.BasicAtom;
-import at.ac.tuwien.kr.alpha.common.atoms.BasicLiteral;
-import at.ac.tuwien.kr.alpha.common.atoms.Literal;
 import at.ac.tuwien.kr.alpha.common.program.InputProgram;
-import at.ac.tuwien.kr.alpha.common.rule.BasicRule;
-import at.ac.tuwien.kr.alpha.common.rule.InternalRule;
-import at.ac.tuwien.kr.alpha.common.rule.NormalRule;
 import at.ac.tuwien.kr.alpha.common.terms.ConstantTerm;
-import at.ac.tuwien.kr.alpha.common.terms.FunctionTerm;
 import at.ac.tuwien.kr.alpha.common.terms.Term;
 import at.ac.tuwien.kr.alpha.common.terms.VariableTerm;
 import at.ac.tuwien.kr.alpha.grounder.parser.ProgramParser;
-import at.ac.tuwien.kr.alpha.test.util.SubstitutionTestUtil;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class UnifierTest extends SubstitutionTest {
 
@@ -88,88 +77,5 @@ public class UnifierTest extends SubstitutionTest {
 		ProgramParser programParser = new ProgramParser();
 		InputProgram program = programParser.parse(atom + ".");
 		return (BasicAtom) program.getFacts().get(0);
-	}
-
-	@Test
-	@Override
-	public void unifyTermsSimpleBinding() throws Exception {
-		Substitution substitution = new Unifier();
-		substitution.unifyTerms(Y, A);
-		assertEquals(A, substitution.eval(Y));
-	}
-
-	@Test
-	@Override
-	public void unifyTermsFunctionTermBinding() throws Exception {
-		Substitution substitution = new Unifier();
-		substitution.put(Y, A);
-
-		FunctionTerm groundFunctionTerm = FunctionTerm.getInstance("f", B, C);
-		Term nongroundFunctionTerm = FunctionTerm.getInstance("f", B, X);
-
-		substitution.unifyTerms(nongroundFunctionTerm, groundFunctionTerm);
-
-		assertEquals(C, substitution.eval(X));
-		assertEquals(A, substitution.eval(Y));
-	}
-
-	@Test
-	@Override
-	public void substitutePositiveBasicAtom() {
-		substituteBasicAtomLiteral(false);
-	}
-
-	@Test
-	@Override
-	public void substituteNegativeBasicAtom() {
-		substituteBasicAtomLiteral(true);
-	}
-
-	@Test
-	@Override
-	public void groundAndPrintRule() {
-		BasicRule rule = PARSER.parse("x :- p(X,Y), not q(X,Y).").getRules().get(0);
-		InternalRule nonGroundRule = InternalRule.fromNormalRule(NormalRule.fromBasicRule(rule));
-		Substitution substitution = new Unifier();
-		substitution.unifyTerms(X, A);
-		substitution.unifyTerms(Y, B);
-		String printedString = SubstitutionTestUtil.groundAndPrintRule(nonGroundRule, substitution);
-		assertEquals("x :- p(a, b), not q(a, b).", printedString);
-	}
-
-	private void substituteBasicAtomLiteral(boolean negated) {
-		Predicate p = Predicate.getInstance("p", 2);
-		BasicAtom atom = new BasicAtom(p, Arrays.asList(X, Y));
-		Literal literal = new BasicLiteral(atom, !negated);
-		Substitution substitution = new Unifier();
-		substitution.unifyTerms(X, A);
-		substitution.unifyTerms(Y, B);
-		literal = literal.substitute(substitution);
-		assertEquals(p, literal.getPredicate());
-		assertEquals(A, literal.getTerms().get(0));
-		assertEquals(B, literal.getTerms().get(1));
-		assertEquals(negated, literal.isNegated());
-	}
-
-	@Test
-	@Override
-	public void groundLiteralToString_PositiveBasicAtom() {
-		groundLiteralToString(false);
-	}
-
-	@Test
-	@Override
-	public void groundLiteralToString_NegativeBasicAtom() {
-		groundLiteralToString(true);
-	}
-
-	private void groundLiteralToString(boolean negated) {
-		Predicate p = Predicate.getInstance("p", 2);
-		BasicAtom atom = new BasicAtom(p, Arrays.asList(X, Y));
-		Substitution substitution = new Unifier();
-		substitution.unifyTerms(X, A);
-		substitution.unifyTerms(Y, B);
-		String printedString = SubstitutionTestUtil.groundLiteralToString(atom.toLiteral(!negated), substitution, true);
-		assertEquals((negated ? "not " : "") + "p(a, b)", printedString);
 	}
 }


### PR DESCRIPTION
Removes the need for upfront cloning of Substitutions when checking unification.