### PR TITLE
Fix javadoc error in Unifier

### DIFF
--- a/src/main/java/at/ac/tuwien/kr/alpha/grounder/Unifier.java
+++ b/src/main/java/at/ac/tuwien/kr/alpha/grounder/Unifier.java
@@ -14,7 +14,7 @@ import at.ac.tuwien.kr.alpha.common.terms.VariableTerm;
 
 /**
  * A variable substitution allowing variables to occur on the right-hand side. Chains of variable substitutions are
- * resolved automatically, i.e., adding the substitutions (X -> A) and (A -> d) results in (X -> d), (A -> d).
+ * resolved automatically, i.e., adding the substitutions {@literal (X -> A)} and {@literal (A -> d)} results in {@literal (X -> d)}, {@literal (A -> d)}.
  * Copyright (c) 2018-2020, the Alpha Team.
  */
 public class Unifier extends Substitution {
@@ -97,8 +97,8 @@ public class Unifier extends Substitution {
 	/**
 	 * Merge substitution right into left as used in the AnalyzeUnjustified.
 	 * Left mappings are seen as equalities, i.e.,
-	 * if left has A -> B and right has A -> t then the result will have A -> t and B -> t.
-	 * If both substitutions are inconsistent, i.e., A -> t1 in left and A -> t2 in right, then null is returned.
+	 * if left has {@literal A -> B} and right has {@literal A -> t} then the result will have {@literal A -> t} and {@literal B -> t}.
+	 * If both substitutions are inconsistent, i.e., {@literal A -> t1} in left and {@literal A -> t2} in right, then null is returned.
 	 * @param left
 	 * @param right
 	 * @return


### PR DESCRIPTION
javadoc doesn't like `>` symbols. One way to solve this is to wrap them
`@literal`
#193 