### PR TITLE
ci: Clean up GitHub Actions spec

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,25 +32,27 @@ jobs:
       # OS to be the "main" one.
       MAIN_OS: ubuntu
     steps:
+    # See https://github.com/marketplace/actions/checkout
     - uses: actions/checkout@v2
       with:
         submodules: recursive
         fetch-depth: 0
+    # See https://github.com/marketplace/actions/gradle-wrapper-validation
+    - uses: gradle/wrapper-validation-action@v1
+    # See https://github.com/marketplace/actions/setup-java-jdk
     - uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
-        architecture: x64
-        cache: 'gradle'
-
-    - run: ./gradlew build --stacktrace
-      if: runner.os != 'Windows'
-    - run: .\gradlew build --stacktrace
-      if: runner.os == 'Windows'
-
-    - run: ./gradlew jacocoTestReport coveralls
+    # See https://github.com/marketplace/actions/gradle-build-action
+    - uses: gradle/gradle-build-action@v2
+      with:
+        arguments: build --stacktrace
+    - uses: gradle/gradle-build-action@v2
       if: matrix.os == env.MAIN_OS && matrix.java == env.MAIN_JAVA
       continue-on-error: true
+      with:
+        arguments: jacocoTestReport coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     - uses: codecov/codecov-action@v1


### PR DESCRIPTION
Improvements to our GitHub Actions configuration:

### Action `gradle/wrapper-validation-action`

Checks that the file at `/gradle/wrapper/gradle-wrapper.jar` is known (on some allowlist). Raises the bar for someone to push a malicious JAR file to this repo.

### Action `gradle/gradle-build-action`

Is a platform-independent way to invoke Gradle, and automatically handles caching. This way we don't have to provide different ways to invoke Gradle based on `matrix.os`.