### PR TITLE
Add `CITATION.cff`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 - family-names: "Langowski"
   given-names: "Michael"
   affiliation: "TU Wien"
-  #orcid: TODO
+  orcid: "https://orcid.org/0000-0001-6572-0357"
 - family-names: "Leutgeb"
   given-names: "Lorenz"
   affiliation: "TU Wien"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,35 @@
+# https://citation-file-format.github.io/
+cff-version: 1.2.0
+message: "If you use this software, please cite it using these metadata."
+title: "Alpha"
+abstract: "A lazy-grounding Answer-Set Programming System"
+# Authors are sorted:
+# First people, sorted by `family-names`, `given-names`.
+# Second entities, sorted by `name`.
+authors:
+- family-names: "Langowski"
+  given-names: "Michael"
+  affiliation: "TU Wien"
+  #orcid: TODO
+- family-names: "Leutgeb"
+  given-names: "Lorenz"
+  affiliation: "TU Wien"
+  orcid: "https://orcid.org/0000-0003-0391-3430"
+- family-names: "Taupe"
+  given-names: "Richard"
+  affiliation: "Siemens AG"
+  orcid: "https://orcid.org/0000-0001-7639-1616"
+- family-names: "Weinzierl"
+  given-names: "Antonius"
+  affiliation: "TU Wien"
+  orcid: "https://orcid.org/0000-0003-2040-6123"
+license: "BSD-2-Clause"
+repository-code: "https://github.com/alpha-asp/alpha"
+doi: "10.5281/zenodo.1418963"
+identifiers:
+  - description: "v0.4.0"
+    type: doi
+    value: "10.5281/zenodo.2641359"
+  - description: "v0.3.0"
+    type: doi
+    value: "10.5281/zenodo.1418964"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -61,3 +61,5 @@ $ cp build/distributions/alpha.zip alpha.zip
 Attach the two files to the release on GitHub, then publish the release. Lastly, check that everything is fine,
 e.g. that the tag/version really points at the revision you wanted to rlease and that `alpha.zip` and `alpha.jar
 downloaded from GitHub do what they are supposed to do.
+
+Optionally, archive the release on Zenodo. If you do so, add the new identifier to `CITATION.cff`.


### PR DESCRIPTION
For more context, refer to:
 * [citation-file-format.github.io](https://citation-file-format.github.io/)
 * [Supported by GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files)
 * [Supported by Zenodo](https://twitter.com/ZENODO_ORG/status/1420357001490706442)
 * [Supported by Zotero](https://twitter.com/zotero/status/1420515377390530560)

The file should not see many changes (just like `AUTHORS` and `CONTRIBUTORS`). The [spec is quite broad and flexible](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md), so we could encode *much* more, but I'd prefer to start with something simple.

Opinions?