### PR TITLE
cli: Upgrade Log4j

### DIFF
--- a/alpha-cli-app/build.gradle.kts
+++ b/alpha-cli-app/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 	implementation("org.apache.poi:poi-ooxml:${poiVersion}")
 
 	// Logging Implementation and SLF4J
-	implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.14.1") {
+	implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0") {
 		// Exclude the SLF4J API, because we already have it via `alpha.java-application-conventions`.
 		exclude("org.slf4j", "slf4j-api")
 	}


### PR DESCRIPTION
[CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228) is making news. AFAIK Alpha is not vulnerable, and, as a CLI application, also not really a target, but let's update Log4j anyway.