### PR TITLE
Fix handling of aggregate literals with only a right-hand comparison term (Issue #311)

### DIFF
--- a/alpha-core/src/main/java/at/ac/tuwien/kr/alpha/core/programs/transformation/aggregates/AggregateOperatorNormalization.java
+++ b/alpha-core/src/main/java/at/ac/tuwien/kr/alpha/core/programs/transformation/aggregates/AggregateOperatorNormalization.java
@@ -70,14 +70,22 @@ public final class AggregateOperatorNormalization {
 	private static List<Literal> rewriteAggregateOperator(AggregateLiteral lit) {
 		AggregateAtom atom = lit.getAtom();
 		if (atom.getLowerBoundOperator() == null && atom.getUpperBoundOperator() != null) {
-			return rewriteAggregateOperator(
-				Atoms.newAggregateAtom(
+			ComparisonOperator operator = atom.getUpperBoundOperator();
+			AggregateLiteral flipped; // "flip" right-hand operator and term to left-hand ones.
+			if (operator.equals(ComparisonOperators.EQ) || operator.equals(ComparisonOperators.NE)) {
+				flipped = Atoms.newAggregateAtom(
+					atom.getUpperBoundOperator(), 
+					atom.getUpperBoundTerm(), 
+					atom.getAggregateFunction(), 
+					atom.getAggregateElements()).toLiteral(!lit.isNegated());
+			} else {
+				flipped = Atoms.newAggregateAtom(
 					atom.getUpperBoundOperator().negate(), 
 					atom.getUpperBoundTerm(), 
 					atom.getAggregateFunction(), 
-					atom.getAggregateElements())
-					.toLiteral(!lit.isNegated())
-				);
+					atom.getAggregateElements()).toLiteral(!lit.isNegated());
+			}
+			return rewriteAggregateOperator(flipped);
 		}
 		if (lit.getAtom().getAggregateFunction() == AggregateFunctionSymbol.MIN || lit.getAtom().getAggregateFunction() == AggregateFunctionSymbol.MAX) {
 			// No operator normalization needed for #min/#max aggregates.

--- a/alpha-core/src/main/java/at/ac/tuwien/kr/alpha/core/programs/transformation/aggregates/AggregateOperatorNormalization.java
+++ b/alpha-core/src/main/java/at/ac/tuwien/kr/alpha/core/programs/transformation/aggregates/AggregateOperatorNormalization.java
@@ -39,8 +39,8 @@ import at.ac.tuwien.kr.alpha.core.rules.BasicRule;
  * </ul>
  * Operators for "#min" and "#max" aggregates are not rewritten.
  * 
- * Note that input programs must only contain aggregate literals of form <code>VAR OP #aggr{...}</code>, i.e. with only
- * a left term and operator. When preprocessing programs, apply this transformation AFTER
+ * Note that input programs must only contain aggregate literals of form <code>TERM OP #aggr{...}</code> or <code>#aggr{...} OP TERM</code>, i.e. with only
+ * a left or right term and operator (but not both). When preprocessing programs, apply this transformation AFTER
  * {@link at.ac.tuwien.kr.alpha.grounder.transformation.aggregates.AggregateLiteralSplitting}.
  * 
  * Copyright (c) 2020-2021, the Alpha Team.
@@ -69,6 +69,16 @@ public final class AggregateOperatorNormalization {
 
 	private static List<Literal> rewriteAggregateOperator(AggregateLiteral lit) {
 		AggregateAtom atom = lit.getAtom();
+		if (atom.getLowerBoundOperator() == null && atom.getUpperBoundOperator() != null) {
+			return rewriteAggregateOperator(
+				Atoms.newAggregateAtom(
+					atom.getUpperBoundOperator().negate(), 
+					atom.getUpperBoundTerm(), 
+					atom.getAggregateFunction(), 
+					atom.getAggregateElements())
+					.toLiteral(!lit.isNegated())
+				);
+		}
 		if (lit.getAtom().getAggregateFunction() == AggregateFunctionSymbol.MIN || lit.getAtom().getAggregateFunction() == AggregateFunctionSymbol.MAX) {
 			// No operator normalization needed for #min/#max aggregates.
 			return Collections.singletonList(lit);

--- a/alpha-core/src/test/java/at/ac/tuwien/kr/alpha/core/programs/transformation/aggregates/AggregateOperatorNormalizationTest.java
+++ b/alpha-core/src/test/java/at/ac/tuwien/kr/alpha/core/programs/transformation/aggregates/AggregateOperatorNormalizationTest.java
@@ -155,7 +155,10 @@ public class AggregateOperatorNormalizationTest {
 		ArithmeticTerm incrementTerm = (ArithmeticTerm) comparisonRightHandTerm;
 		assertEquals(ArithmeticOperator.PLUS, incrementTerm.getOperator());
 		assertEquals(Terms.newConstant(1), incrementTerm.getRightOperand());
-		assertEquals(sourceAggregate.getAtom().getLowerBoundTerm(), incrementTerm.getLeftOperand());
+		Term sourceBound = sourceAggregate.getAtom().getLowerBoundTerm() != null ? 
+			sourceAggregate.getAtom().getLowerBoundTerm() 
+			: sourceAggregate.getAtom().getUpperBoundTerm();
+		assertEquals(sourceBound, incrementTerm.getLeftOperand());
 	}
 
 }

--- a/alpha-core/src/test/java/at/ac/tuwien/kr/alpha/core/programs/transformation/aggregates/AggregateOperatorNormalizationTest.java
+++ b/alpha-core/src/test/java/at/ac/tuwien/kr/alpha/core/programs/transformation/aggregates/AggregateOperatorNormalizationTest.java
@@ -38,10 +38,10 @@ public class AggregateOperatorNormalizationTest {
 			"bla :- dom(X), not X > #count{N : thing(N)}.";
 	public static final String OPERATOR_NORMALIZATION_GE_NEG_ASP =
 			"bla :- dom(X), not X >= #count{N : thing(N)}.";
-	/*
-	 * See github issue #311:
+	/**
 	 * Operator normalization must also make sure that literals with only a right-hand term
 	 * are normalized to left-hand term only (and then operator-normalized if necessary) 
+	 * @see <a href="https://github.com/alpha-asp/alpha/issues/311">#311</a> 
 	 */
 	public static final String OPERATOR_NORMALIZATION_RIGHT_OP_ONLY =
 			"bla :- dom(X), #count{N : thing(N)} < X.";

--- a/alpha-core/src/test/java/at/ac/tuwien/kr/alpha/core/programs/transformation/aggregates/AggregateOperatorNormalizationTest.java
+++ b/alpha-core/src/test/java/at/ac/tuwien/kr/alpha/core/programs/transformation/aggregates/AggregateOperatorNormalizationTest.java
@@ -38,6 +38,13 @@ public class AggregateOperatorNormalizationTest {
 			"bla :- dom(X), not X > #count{N : thing(N)}.";
 	public static final String OPERATOR_NORMALIZATION_GE_NEG_ASP =
 			"bla :- dom(X), not X >= #count{N : thing(N)}.";
+	/*
+	 * See github issue #311:
+	 * Operator normalization must also make sure that literals with only a right-hand term
+	 * are normalized to left-hand term only (and then operator-normalized if necessary) 
+	 */
+	public static final String OPERATOR_NORMALIZATION_RIGHT_OP_ONLY =
+			"bla :- dom(X), #count{N : thing(N)} < X.";
 	//@formatter:on
 
 	@Test
@@ -101,6 +108,14 @@ public class AggregateOperatorNormalizationTest {
 		Rule<Head> inputRule = RuleParser.parse(OPERATOR_NORMALIZATION_GE_NEG_ASP);
 		Rule<Head> rewritten = AggregateOperatorNormalization.normalize(inputRule);
 		assertOperatorNormalized(rewritten, ComparisonOperators.LE, true);
+		assertAggregateBoundIncremented(inputRule, rewritten);
+	}
+
+	@Test
+	public void normalizeRightHandComparison() {
+		Rule<Head> inputRule = RuleParser.parse(OPERATOR_NORMALIZATION_RIGHT_OP_ONLY);
+		Rule<Head> rewritten = AggregateOperatorNormalization.normalize(inputRule);
+		assertOperatorNormalized(rewritten, ComparisonOperators.LE, false);
 		assertAggregateBoundIncremented(inputRule, rewritten);
 	}
 

--- a/alpha-core/src/test/java/at/ac/tuwien/kr/alpha/core/solver/AggregatesTest.java
+++ b/alpha-core/src/test/java/at/ac/tuwien/kr/alpha/core/solver/AggregatesTest.java
@@ -335,4 +335,36 @@ public class AggregatesTest {
 				"full(2)");
 	}
 
+	@AggregateRegressionTest
+	public void aggregateRightHandTermCountGreater(RegressionTestConfig cfg) {
+		String program = "p(1)." + 
+			"p(2)." + 
+			"q :- #count { N : p(N) } > 1.";
+		assertRegressionTestAnswerSet(cfg, program, "p(1), p(2), q");
+	}
+
+	@AggregateRegressionTest
+	public void aggregateRightHandTermCountEqAssigning(RegressionTestConfig cfg) {
+		String program = "p(1)." + 
+			"p(2)." + 
+			"q :- #count { N : p(N) } = 2.";
+		assertRegressionTestAnswerSet(cfg, program, "p(1), p(2), q");
+	}
+
+	@AggregateRegressionTest
+	public void aggregateRightHandTermCountNeqAssigning(RegressionTestConfig cfg) {
+		String program = "p(1)." + 
+			"p(2)." + 
+			"q :- #count { N : p(N) } != 1.";
+		assertRegressionTestAnswerSet(cfg, program, "p(1), p(2), q");
+	}
+
+	@AggregateRegressionTest
+	public void aggregateRightHandTermCountLt(RegressionTestConfig cfg) {
+		String program = "p(1)." + 
+			"p(2)." + 
+			"q :- #count { N : p(N) } < 3.";
+		assertRegressionTestAnswerSet(cfg, program, "p(1), p(2), q");
+	}
+
 }


### PR DESCRIPTION
Fixed in `AggregateOperatorNormalization`:
Aggregates of form `#aggr{...} OP TERM` are rewritten into `TERM inv(OP) #aggr{...}` and then processed as before.
`inv(OP)` refers to the inverse operator, i.e. `inv(<) = >=` etc. For operators `=` and `!=` no inverse operator is used, i.e. rewritten form is `TERM OP #aggr{...}`.

Closes #311 