### PR TITLE
release preparation: set version to 0.6.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.6-SNAPSHOT
+version=0.6.0
 group=at.ac.tuwien.kr.alpha
 org.gradle.warning.mode=all


### PR DESCRIPTION
In preparation for the actual release of version 0.6.0, we need to set the correct version in gradle.properties before we can create the tag