### PR TITLE
bump version to 0.7.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.6.0
+version=0.7.0-SNAPSHOT
 group=at.ac.tuwien.kr.alpha
 org.gradle.warning.mode=all


### PR DESCRIPTION
Tag for release v0.6.0 has been created, now set the version in `master` to 0.7.0-SNAPSHOT