### PR TITLE
Build Properties

### DIFF
--- a/alpha-cli-app/build.gradle.kts
+++ b/alpha-cli-app/build.gradle.kts
@@ -40,6 +40,10 @@ tasks.create<Jar>("bundledJar") {
 	archiveFileName.set("${project.name}-${project.version}-bundled.jar")
 
 	exclude("META-INF/DEPENDENCIES")
+
+	filesMatching("META-INF/build.properties") {
+		duplicatesStrategy = DuplicatesStrategy.INCLUDE
+	}
 	
 	/*
 	 * In order to make sure we don"t overwrite NOTICE and LICENSE files coming from dependency

--- a/buildSrc/src/main/kotlin/alpha.java-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/alpha.java-common-conventions.gradle.kts
@@ -64,6 +64,16 @@ tasks.jacocoTestReport {
 	}
 }
 
+tasks.register<WriteProperties>("buildProperties") {
+	outputFile = file("${sourceSets["main"].output.resourcesDir}/META-INF/build.properties")
+	encoding = "UTF-8"
+	property("project.version", project.version)
+}
+
+tasks.processResources {
+	dependsOn("buildProperties")
+}
+
 publishing {
 	publications {
 		create<MavenPublication>("binary") {


### PR DESCRIPTION
Introduce a mechanism to pass "Build Properties" (version number, hash of the source revision, etc.) to the resulting artifact. Mainly to allow Alpha report its own version, which is implemented as example.

This contents of `META-INF/build.properties` must be kept reproducible, i.e. only depend on our Git repository as input, not use timestamps, current hostname or weather...