### PR TITLE
core: fix vendored path config for benchmark files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,4 +16,4 @@
 *.gpg  filter=lfs diff=lfs merge=lfs binary
 *.bin  filter=lfs diff=lfs merge=lfs binary
 
-benchmarks/omiga/** linguist-vendored
+alpha-core/benchmarks/** linguist-vendored


### PR DESCRIPTION
This is a leftover from PR #274: The path `benchmarks/**`, containing an enormous amount of ASP sources, should be marked as vendored, i.e. excluded from github statistics. Since the folder in question got moved into `alpha-core`, we need to adapt the config in `.gitattributes` accordingly.