### PR TITLE
Revise RuleAtomData#compareTo

### DIFF
--- a/alpha-commons/src/main/java/at/ac/tuwien/kr/alpha/commons/substitutions/BasicSubstitution.java
+++ b/alpha-commons/src/main/java/at/ac/tuwien/kr/alpha/commons/substitutions/BasicSubstitution.java
@@ -193,7 +193,7 @@ public class BasicSubstitution implements at.ac.tuwien.kr.alpha.api.grounder.Sub
 
 	@Override
 	public boolean isVariableSet(VariableTerm variable) {
-		return substitution.get(variable) != null;
+		return substitution.containsKey(variable);
 	}
 
 	public Set<VariableTerm> getMappedVariables() {


### PR DESCRIPTION
Eliminates the implicit assumption for two compared `RuleAtomData`s to have the same variables set and instead works off the occurring variables of the rule.