### PR TITLE
ci: Upgrade actions/setup-java

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
     # See https://github.com/marketplace/actions/gradle-wrapper-validation
     - uses: gradle/wrapper-validation-action@v1
     # See https://github.com/marketplace/actions/setup-java-jdk
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'


### PR DESCRIPTION
To work around deprecation of `set-output`, see also https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/