### PR TITLE
Add Jacoco aggregation for coverage.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
       if: matrix.os == env.MAIN_OS && matrix.java == env.MAIN_JAVA
       continue-on-error: true
       with:
-        arguments: jacocoTestReport coveralls
+        arguments: jacocoAggregatedTestReport coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     - uses: codecov/codecov-action@v1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,26 @@
 plugins {
 	jacoco
-
 	id("com.github.kt3k.coveralls") version "2.12.0"
+	id("jacoco-report-aggregation")
 }
 
 tasks.wrapper {
 	gradleVersion = "7.6"
 	distributionType = Wrapper.DistributionType.ALL
+}
+
+dependencies {
+	jacocoAggregation(project(":alpha-cli-app"))
+}
+
+reporting {
+	reports {
+		val jacocoAggregatedTestReport by creating(JacocoCoverageReport::class) {
+			testType.set(TestSuiteType.UNIT_TEST)
+		}
+	}
+}
+
+repositories {
+	mavenCentral { metadataSources { mavenPom() } }
 }


### PR DESCRIPTION
Refactoring Alpha into modules resulted in coverage to be computed only individually for each module. This results in many lines of code being considered not hit by any test, while they indeed are tested in (functional-/integration-)tests of another module. This PR tries to rectify coverage computation by using Jacoco's aggregate plugin on the top-level of the build.